### PR TITLE
fix: parse aggregate field names with whitespace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - Replace deprecated/internal R C API usage with public accessors where possible.
 - Support `dynlist()` for macOS dyld shared cache libraries.
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.
+- Store aggregate field names in the explicit `typeinfo$fields$name` column.
 - Refresh roxygen-generated documentation and package metadata for renewed development.
 - Modernize GitHub Actions checks across Linux, macOS, and Windows, with an optional R-hub workflow for extended platform checks.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Update the bundled dyncall source and stop tracking generated static libraries.
 - Replace deprecated/internal R C API usage with public accessors where possible.
 - Support `dynlist()` for macOS dyld shared cache libraries.
+- Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.
 - Refresh roxygen-generated documentation and package metadata for renewed development.
 - Modernize GitHub Actions checks across Linux, macOS, and Windows, with an optional R-hub workflow for extended platform checks.
 

--- a/R/dynport.R
+++ b/R/dynport.R
@@ -523,7 +523,7 @@ dynport_parse_struct_union <- function(value, lnum = 1L, envir = parent.frame(),
             fields <- NULL
         } else {
             # TODO: invalid field names?
-            fields <- strsplit(trimws(tail[[2L]]), "[ \r\n\t]+")[[1L]]
+            fields <- parse_field_names(tail[[2L]])
             # this is the case when there are extra '}'
             if (!length(fields)) {
                 issue_error(name, "Extra '}' in specification")
@@ -559,7 +559,7 @@ dynport_parse_struct_union <- function(value, lnum = 1L, envir = parent.frame(),
         out[[i]] <- typeinfo(
             name = name, type = kind,
             size = parsed$size, align = parsed$align,
-            fields = data.frame(name = fields, type = parsed$type, offset = parsed$offset)
+            fields = make_field_info(fields, parsed$type, parsed$offset)
         )
     }
 

--- a/R/struct.R
+++ b/R/struct.R
@@ -52,8 +52,8 @@
 #'
 #' @param envir the environment to look for type object.
 #'
-#' @param fields data frame with type and offset information that specifies
-#'        aggregate struct and union types.
+#' @param fields data frame with name, type and offset information that
+#'        specifies aggregate struct and union types.
 #'
 #' @return
 #' List object tagged as S3 class `typeinfo` with the following named entries
@@ -62,6 +62,7 @@
 #' \item{align}{Alignment in bytes.}
 #' \item{fields}{Data frame for field information with the following columns:
 #'     \tabular{ll}{
+#'         \code{name} \tab field name\cr
 #'         \code{type} \tab type name\cr
 #'         \code{offset} \tab byte offset (starts counted from 0)\cr
 #'     }
@@ -146,7 +147,11 @@ align <- function(offset, alignment) {
 # field information (structures and unions)
 
 make_field_info <- function(field_names, types, offsets) {
-    data.frame(type = I(types), offset = offsets, row.names = field_names)
+    if (is.null(field_names)) field_names <- character()
+    if (length(types) != length(field_names)) {
+        stop("number of field types and names does not match")
+    }
+    data.frame(name = field_names, type = I(types), offset = offsets)
 }
 
 parse_field_names <- function(x) {
@@ -452,9 +457,10 @@ cdata <- function(type) {
     struct_name <- attr(x, "struct")
     struct_info <- get_typeinfo(struct_name)
     field_info <- struct_info$fields
-    offset <- field_info[index, "offset"]
-    if (is.na(offset)) stop("unknown field index '", index, "'")
-    field_type_name <- as.character(field_info[[index, "type"]])
+    field_index <- match(index, field_info$name)
+    if (is.na(field_index)) stop("unknown field index '", index, "'")
+    offset <- field_info[field_index, "offset"]
+    field_type_name <- as.character(field_info[[field_index, "type"]])
     field_type_info <- get_typeinfo(field_type_name)
     if (field_type_info$type %in% c("base", "pointer")) {
         unpack(x, offset, field_type_info$signature)
@@ -476,9 +482,10 @@ cdata <- function(type) {
     struct_name <- attr(x, "struct")
     struct_info <- get_typeinfo(struct_name)
     field_info <- struct_info$fields
-    offset <- field_info[index, "offset"]
-    if (is.na(offset)) stop("unknown field index '", index, "'")
-    field_type_name <- as.character(field_info[index, "type"])
+    field_index <- match(index, field_info$name)
+    if (is.na(field_index)) stop("unknown field index '", index, "'")
+    offset <- field_info[field_index, "offset"]
+    field_type_name <- as.character(field_info[field_index, "type"])
     field_type_info <- get_typeinfo(field_type_name)
     if (field_type_info$type %in% c("base", "pointer")) {
         pack(x, offset, field_type_info$signature, value)
@@ -498,7 +505,7 @@ print.struct <- function(x, indent = 0, ...) {
     struct_name <- attr(x, "struct")
     struct_info <- get_typeinfo(struct_name)
     field_info <- struct_info$fields
-    field_names <- rownames(field_info)
+    field_names <- field_info$name
 
     cat("struct ", struct_name, " ")
     if (typeof(x) == "externalptr") {

--- a/R/struct.R
+++ b/R/struct.R
@@ -149,6 +149,12 @@ make_field_info <- function(field_names, types, offsets) {
     data.frame(type = I(types), offset = offsets, row.names = field_names)
 }
 
+parse_field_names <- function(x) {
+    x <- trimws(x)
+    if (!nzchar(x)) return(NULL)
+    strsplit(x, "[ \n\t]+")[[1L]]
+}
+
 # ----------------------------------------------------------------------------
 # parse structure signature
 
@@ -336,7 +342,7 @@ cstruct <- function(sigs, envir = parent.frame()) {
             tail <- unlist(strsplit(sigs[[i]][[2]], "[}]"))
             sig <- tail[[1]]
             if (length(tail) == 2) {
-                fields <- unlist(strsplit(tail[[2]], "[ \n\t]+"))
+                fields <- parse_field_names(tail[[2]])
             } else {
                 fields <- NULL
             }
@@ -400,7 +406,7 @@ cunion <- function(sigs, envir = parent.frame()) {
             tail <- unlist(strsplit(sigs[[i]][[2]], "[}]"))
             sig <- tail[[1]]
             if (length(tail) == 2) {
-                fields <- unlist(strsplit(tail[[2]], "[ \n\t]+"))
+                fields <- parse_field_names(tail[[2]])
             } else {
                 fields <- NULL
             }

--- a/inst/tinytest/test_dynstruct.R
+++ b/inst/tinytest/test_dynstruct.R
@@ -27,6 +27,8 @@ expect_equal(rdyncall:::align(4, 8), 8L)
 
 env <- new.env()
 expect_null(cstruct("Rect{ssSS}x y w h ;", env))
+expect_null(cstruct("RectWithSpace{ssSS} x y w h ;", env))
+expect_null(cunion("NumberWithSpace|id} i d ;", env))
 expect_equal(
     env$Rect,
     structure(
@@ -41,3 +43,5 @@ expect_equal(
         ), class = "typeinfo"
     )
 )
+expect_equal(rownames(env$RectWithSpace$fields), c("x", "y", "w", "h"))
+expect_equal(rownames(env$NumberWithSpace$fields), c("i", "d"))

--- a/inst/tinytest/test_dynstruct.R
+++ b/inst/tinytest/test_dynstruct.R
@@ -35,13 +35,19 @@ expect_equal(
         list(name = "Rect", type = "struct", size = .Machine$sizeof.pointer,
             align = 2, basetype = NA,
             fields = data.frame(
+                name = c("x", "y", "w", "h"),
                 type = I(c("s", "s", "S", "S")),
-                offset = c(0L, 2L, 4L, 6L),
-                row.names = c("x", "y", "w", "h")
+                offset = c(0L, 2L, 4L, 6L)
             ),
             signature = NA
         ), class = "typeinfo"
     )
 )
-expect_equal(rownames(env$RectWithSpace$fields), c("x", "y", "w", "h"))
-expect_equal(rownames(env$NumberWithSpace$fields), c("i", "d"))
+expect_equal(env$RectWithSpace$fields$name, c("x", "y", "w", "h"))
+expect_equal(env$NumberWithSpace$fields$name, c("i", "d"))
+
+parsed_struct <- rdyncall:::dynport_parse_struct("Rect{ssSS} x y w h;")
+expect_equal(parsed_struct$Rect$fields, env$RectWithSpace$fields)
+
+parsed_union <- rdyncall:::dynport_parse_union("Number{id} i d;")
+expect_equal(parsed_union$Number$fields, env$NumberWithSpace$fields)

--- a/man/typeinfo.Rd
+++ b/man/typeinfo.Rd
@@ -29,8 +29,8 @@ get_typeinfo(name, envir = parent.frame())
 
 \item{basetype}{character string, base type of 'pointer' types.}
 
-\item{fields}{data frame with type and offset information that specifies
-aggregate struct and union types.}
+\item{fields}{data frame with name, type and offset information that
+specifies aggregate struct and union types.}
 
 \item{signature}{character string specifying the struct/union type
 \link[=type-signature]{signature}.}
@@ -44,6 +44,7 @@ List object tagged as S3 class \code{typeinfo} with the following named entries
 \item{align}{Alignment in bytes.}
 \item{fields}{Data frame for field information with the following columns:
 \tabular{ll}{
+\code{name} \tab field name\cr
 \code{type} \tab type name\cr
 \code{offset} \tab byte offset (starts counted from 0)\cr
 }


### PR DESCRIPTION
## Summary

Closes #6.

Fix aggregate field parsing when whitespace follows the closing brace, and normalize aggregate field metadata so field names live in the explicit `typeinfo$fields$name` column.

## Changes

- Share field-name parsing between `cstruct()`, `cunion()`, and dynport aggregate parsing.
- Store aggregate fields as `name` / `type` / `offset` columns instead of using row names for field semantics.
- Update struct field access, printing, tests, NEWS, and roxygen-generated documentation for the new metadata shape.

## Out of scope

- No C-layer parser migration in this PR.
- No changes to dyncall call/pack/unpack ABI behavior.