### PR TITLE
feat: allow configuring CallVM size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Support `dynlist()` for macOS dyld shared cache libraries.
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.
 - Store aggregate field names in the explicit `typeinfo$fields$name` column.
+- Add the `rdyncall.callvm.size` option to configure CallVM argument stack size at package load.
 - Refresh roxygen-generated documentation and package metadata for renewed development.
 - Modernize GitHub Actions checks across Linux, macOS, and Windows, with an optional R-hub workflow for extended platform checks.
 

--- a/R/dyncall.R
+++ b/R/dyncall.R
@@ -1,13 +1,24 @@
 # ----------------------------------------------------------------------------
 # call vm alloc/free (internal)
 
+callvm.default.size <- 4096L
+
+callvm_size <- function(size = getOption("rdyncall.callvm.size", callvm.default.size)) {
+    if (!is.numeric(size) || length(size) != 1L || is.na(size) ||
+        !is.finite(size) || size < 1L || size > .Machine$integer.max ||
+        size != floor(size)) {
+        stop("option 'rdyncall.callvm.size' must be a single positive integer", call. = FALSE)
+    }
+    as.integer(size)
+}
+
 callvm_new <- function(
     callmode = c("cdecl", "stdcall", "thiscall", "thiscall.gcc", "thiscall.msvc",
                  "fastcall", "fastcall.gcc", "fastcall.msvc"),
-    size = 4096)
+    size = callvm_size())
 {
     callmode <- match.arg(callmode)
-    x <- .Call("C_callvm_new", callmode, as.integer(size), PACKAGE = "rdyncall")
+    x <- .Call("C_callvm_new", callmode, callvm_size(size), PACKAGE = "rdyncall")
     reg.finalizer(x, callvm_free)
     return(x)
 }
@@ -69,6 +80,11 @@ callvm.fastcall.msvc <- NULL
 #' The calling convention is specified _explicitly_ via function [dyncall()]
 #' using the `callmode` argument or _implicitly_ by using `dyncall.*` functions.
 #' See details below.
+#'
+#' The package option `rdyncall.callvm.size` controls the byte size of the
+#' internal dyncall CallVM argument stack. The default is `4096`. Set this
+#' option before loading \pkg{rdyncall}; changing it after package load does not
+#' resize already-created CallVM objects.
 #'
 #' Arguments passed via `...` are converted to C according to `signature`; see
 #' below for details.
@@ -311,13 +327,14 @@ dyncall.fastcall      <- dyncall.fastcall.gcc
 # initialize callvm's on load
 
 .onLoad <- function(libname, pkgname) {
-    callvm.cdecl         <<- callvm_new("cdecl")
+    size <- callvm_size()
+    callvm.cdecl         <<- callvm_new("cdecl", size)
     callvm.default       <<- callvm.cdecl
-    callvm.stdcall       <<- callvm_new("stdcall")
-    callvm.thiscall      <<- callvm_new("thiscall")
-    callvm.thiscall.gcc  <<- callvm_new("thiscall.gcc")
-    callvm.thiscall.msvc <<- callvm_new("thiscall.msvc")
-    callvm.fastcall      <<- callvm_new("fastcall")
-    callvm.fastcall.gcc  <<- callvm_new("fastcall.gcc")
-    callvm.fastcall.msvc <<- callvm_new("fastcall.msvc")
+    callvm.stdcall       <<- callvm_new("stdcall", size)
+    callvm.thiscall      <<- callvm_new("thiscall", size)
+    callvm.thiscall.gcc  <<- callvm_new("thiscall.gcc", size)
+    callvm.thiscall.msvc <<- callvm_new("thiscall.msvc", size)
+    callvm.fastcall      <<- callvm_new("fastcall", size)
+    callvm.fastcall.gcc  <<- callvm_new("fastcall.gcc", size)
+    callvm.fastcall.msvc <<- callvm_new("fastcall.msvc", size)
 }

--- a/inst/tinytest/test_dyncall.R
+++ b/inst/tinytest/test_dyncall.R
@@ -1,3 +1,33 @@
 f <- function(x, y) x + y
 expect_true(is.externalptr(cb <- ccallback("ii)i", f)))
 expect_equal(dyncall(cb, "ii)i", 20L, 3L), 23L)
+
+run_rdyncall_subprocess <- function(expr) {
+    lib <- dirname(system.file(package = "rdyncall"))
+    code <- paste(sprintf(".libPaths(c(%s, .libPaths()))", shQuote(lib)), expr, sep = "\n")
+    system2(file.path(R.home("bin"), "Rscript"),
+        c("--vanilla", "-e", shQuote(code)),
+        stdout = TRUE, stderr = TRUE
+    )
+}
+
+large_call <- paste(
+    "options(rdyncall.callvm.size = 16384L)",
+    "library(rdyncall)",
+    "n <- 1200L",
+    "sig <- paste0(strrep('i', n), ')i')",
+    "cb <- ccallback(sig, function(...) as.integer(sum(...)))",
+    "ans <- do.call(dyncall, c(list(cb, sig), as.list(rep(1L, n))))",
+    "stopifnot(identical(ans, n))",
+    sep = "\n"
+)
+expect_null(attr(run_rdyncall_subprocess(large_call), "status"))
+
+invalid_size <- paste(
+    "options(rdyncall.callvm.size = 0L)",
+    "library(rdyncall)",
+    sep = "\n"
+)
+out <- suppressWarnings(run_rdyncall_subprocess(invalid_size))
+expect_true(!is.null(attr(out, "status")))
+expect_true(any(grepl("rdyncall.callvm.size", out, fixed = TRUE)))

--- a/man/dyncall.Rd
+++ b/man/dyncall.Rd
@@ -89,6 +89,11 @@ The calling convention is specified \emph{explicitly} via function \code{\link[=
 using the \code{callmode} argument or \emph{implicitly} by using \verb{dyncall.*} functions.
 See details below.
 
+The package option \code{rdyncall.callvm.size} controls the byte size of the
+internal dyncall CallVM argument stack. The default is \code{4096}. Set this
+option before loading \pkg{rdyncall}; changing it after package load does not
+resize already-created CallVM objects.
+
 Arguments passed via \code{...} are converted to C according to \code{signature}; see
 below for details.
 


### PR DESCRIPTION
## Summary

Closes #16.

Add a load-time `rdyncall.callvm.size` option so users can increase the dyncall CallVM argument stack when calling functions with many or large arguments.

## Changes

- Read `rdyncall.callvm.size` during `.onLoad()` and use it for every CallVM instance.
- Validate that the option is a single positive integer before creating CallVM objects.
- Document the option, update NEWS, and cover both a larger-argument call and invalid option handling in tinytest.

## Out of scope

- No runtime CallVM resizing API.
- No changes to the vendored dyncall vector implementation or ABI behavior.
