### PR TITLE
feat(demo): add modern library examples

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,6 +12,8 @@
 ^pkgdown$
 ^src/compile_commands\.json$
 ^\.cache$
+^src/\.cache$
+^tools/\.cache$
 ^src/dyncall/dyncall/libdyncall_s\.a$
 ^src/dyncall/dyncallback/libdyncallback_s\.a$
 ^src/dyncall/dynload/libdynload_s\.a$

--- a/demo/00Index
+++ b/demo/00Index
@@ -1,10 +1,12 @@
 R_ShowMessage   Show R Dialog Message (dynbind demo)
 R_malloc        Using R's memory allocator directly in R (dynbind demo)
 blink           Simple SDL,OpenGL demonstration - a blinking screen (dynport demo)
-SDL             3D Rotating Cube Demo using SDL,OpenGL and GLU. (dynport demo)
+SDL             SDL3 window lifecycle demo.
 randomfield     Scientific Computations using OpenGL: Rendering 512x512 random field by blending 5000 point sprites (dynport demo)
 randomfield2    Scientific Computations using OpenGL: Rendering 512x512 random field by blending 5000 point sprites (dynport demo)
 expat           Parsing XML using expat and callbacks (callback demo)
+libxml2         Parsing XML using direct libxml2 calls and comparing with xml2.
+raylib          raylib window demo using aggregate Color arguments.
 callbacks       Creating a callback and call it via dyncall (dyncall and callback demo)
 factorial       Factorial computation via recursive dyncall calls to callback objects.
 stdio           Direct I/O of R raw vectors using C stdio functions

--- a/demo/SDL.R
+++ b/demo/SDL.R
@@ -1,146 +1,133 @@
-# Package: rdyncall 
+# Package: rdyncall
 # File: demo/SDL.R
-# Description: 3D Rotating Cube Demo using SDL,OpenGL and GLU. (dynport demo)
+# Description: SDL3 window lifecycle demo.
 
-dynport(SDL)
-dynport(GL)
-dynport(GLU)
-
-# Globals.
-
-surface <- NULL
-
-# Init.
-
-init <- function()
-{
-  err <- SDL_Init(SDL_INIT_VIDEO)
-  if (err != 0) error("SDL_Init failed")  
-  surface <<- SDL_SetVideoMode(512,512,32,SDL_DOUBLEBUF+SDL_OPENGL)
-}
-
-# GL Display Lists
-
-makeCubeDisplaylist <- function()
-{
-  vertices <- as.double(c(
-  -1,-1,-1,
-   1,-1,-1,
-  -1, 1,-1,
-   1, 1,-1,
-  -1,-1, 1,
-   1,-1, 1,
-  -1, 1, 1,
-   1, 1, 1
-  ))
-  
-  colors <- as.raw( col2rgb( rainbow(8) ) )
-  
-  triangleIndices <- as.integer(c(
-    0, 2, 1, 
-    2, 3, 1,
-    1, 3, 7, 
-    1, 7, 5,
-    4, 5, 7, 
-    4, 7, 6,
-    6, 2, 0, 
-    6, 0, 4,
-    2, 7, 3, 
-    2, 6, 7,
-    4, 0, 5, 
-    0, 1, 5
-  ))
-
-  glEnableClientState(GL_VERTEX_ARRAY)
-  glVertexPointer(3, GL_DOUBLE, 0, vertices )
-  
-  glEnableClientState(GL_COLOR_ARRAY)  
-  glColorPointer(3, GL_UNSIGNED_BYTE, 0, colors )
-  
-  displaylistId <- glGenLists(1)
-  glNewList( displaylistId, GL_COMPILE )    
-  glPushAttrib(GL_ENABLE_BIT)
-  glEnable(GL_DEPTH_TEST)
-  glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, triangleIndices)
-  glPopAttrib()
-  glEndList()
-  
-  glDisableClientState(GL_VERTEX_ARRAY)
-  glDisableClientState(GL_COLOR_ARRAY)
- 
-
-  return(displaylistId)
-}
-
-# Mainloop.
-
-mainloop <- function()
-{
-  displaylistId <- makeCubeDisplaylist()
-  evt <- cdata(SDL_Event)
-  blink <- 0
-  tbase <- SDL_GetTicks()
-  quit <- FALSE
-  while(!quit)
-  {
-    tnow <- SDL_GetTicks()
-    tdemo <- ( tnow - tbase ) / 1000
-    
-    glClearColor(0,0,blink,0)
-    glClear(GL_COLOR_BUFFER_BIT+GL_DEPTH_BUFFER_BIT)
-    
-    glMatrixMode(GL_PROJECTION)
-    glLoadIdentity()
-    aspect <- 512/512
-    gluPerspective(60, aspect, 3, 1000)
-    
-    glMatrixMode(GL_MODELVIEW)
-    glLoadIdentity()
-    gluLookAt(0,0,5,0,0,0,0,1,0)
-    glRotated(sin(tdemo)*60.0, 0, 1, 0);
-    glRotated(cos(tdemo)*90.0, 1, 0, 0);
-
-    glCallList(displaylistId)       
-
-    glCallList(displaylistId)       
-    
-    SDL_GL_SwapBuffers()  
-    
-    SDL_WM_SetCaption(paste("time:", tdemo),NULL)    
-    blink <- blink + 0.01
-    while (blink > 1) blink <- blink - 1
-    while( SDL_PollEvent(evt) != 0 )
-    {
-      if ( evt$type == SDL_QUIT ) quit <- TRUE
-      else if (evt$type == SDL_MOUSEBUTTONDOWN )
-      {
-        button <- evt$button
-        cat("button ",button$button," at ",button$x,",",button$y,"\n") 
-      }
+load_rdyncall <- function() {
+    if ("package:rdyncall" %in% search()) {
+        return(invisible(TRUE))
     }
-    glerr <- glGetError()
-    if (glerr != 0)
-    {
-      cat("GL Error:", gluErrorString(glerr) )
-      quit <- 1
+    lib.loc <- Sys.getenv("RDYNCALL_LIB", unset = "")
+    if (nzchar(lib.loc)) {
+        return(library("rdyncall", lib.loc = lib.loc, character.only = TRUE))
     }
-    SDL_Delay(30)
-  }
-  glDeleteLists(displaylistId, 1)
+    file <- ""
+    for (frame in rev(sys.frames())) {
+        if (!is.null(frame$ofile)) {
+            file <- normalizePath(frame$ofile, mustWork = FALSE)
+            break
+        }
+    }
+    if (nzchar(file)) {
+        lib.loc <- dirname(dirname(dirname(file)))
+        if (file.exists(file.path(lib.loc, "rdyncall"))) {
+            return(library("rdyncall", lib.loc = lib.loc, character.only = TRUE))
+        }
+    }
+    library("rdyncall", character.only = TRUE)
 }
 
-cleanup <- function()
-{
-  SDL_Quit()
+load_rdyncall()
+
+shared_library_candidates <- function(envvar, names) {
+    env_path <- Sys.getenv(envvar, unset = "")
+    if (nzchar(env_path)) {
+        return(env_path)
+    }
+
+    dirs <- c(
+        "/opt/homebrew/lib",
+        "/usr/local/lib",
+        "/opt/local/lib",
+        "/usr/lib",
+        "/usr/lib/x86_64-linux-gnu",
+        "/usr/lib/aarch64-linux-gnu",
+        "/lib/x86_64-linux-gnu",
+        "/lib/aarch64-linux-gnu"
+    )
+    unique(file.path(rep(dirs, each = length(names)), names))
 }
 
-run <- function()
-{
-  init()
-  mainloop()
-  cleanup()
+bind_library <- function(libnames, signatures, envir, envvar = NULL, path_candidates = character()) {
+    paths <- path_candidates[file.exists(path_candidates)]
+    if (length(paths)) {
+        lib <- dynload(paths[[1L]])
+        if (is.null(lib)) {
+            stop("unable to load shared library: ", paths[[1L]], call. = FALSE)
+        }
+        return(bind_symbols(lib, signatures, envir))
+    }
+
+    tryCatch(
+        dynbind(libnames, signatures, envir = envir),
+        error = function(e) {
+            hint <- if (!is.null(envvar)) paste0(" Set ", envvar, " to the shared library path.") else ""
+            stop(conditionMessage(e), hint, call. = FALSE)
+        }
+    )
 }
 
-run()
+bind_symbols <- function(lib, signatures, envir) {
+    entries <- strsplit(gsub("[ \n\t]*", "", signatures), ";", fixed = TRUE)[[1L]]
+    entries <- entries[nzchar(entries)]
+    unresolved <- character()
 
+    for (entry in entries) {
+        name <- sub("\\(.*$", "", entry)
+        signature <- sub("^[^(]+\\(", "", entry)
+        address <- dynsym(lib, name)
+        if (is.null(address)) {
+            unresolved <- c(unresolved, name)
+            next
+        }
+        f <- function(...) NULL
+        body(f) <- substitute(dyncall(address, signature, ...), list(address = address, signature = signature))
+        environment(f) <- envir
+        assign(name, f, envir = envir)
+    }
 
+    list(libhandle = lib, unresolved.symbols = unresolved)
+}
+
+SDL_INIT_VIDEO <- 0x00000020L
+
+sdl <- new.env(parent = globalenv())
+sdl_info <- bind_library(
+    c("SDL3", "SDL3-0", "SDL3-3"),
+    paste(
+        "SDL_Init(I)B",
+        "SDL_CreateWindow(ZiiL)p",
+        "SDL_Delay(I)v",
+        "SDL_DestroyWindow(p)v",
+        "SDL_Quit()v",
+        "SDL_GetError()Z",
+        sep = ";"
+    ),
+    envir = sdl,
+    envvar = "SDL3_LIB",
+    path_candidates = shared_library_candidates(
+        "SDL3_LIB",
+        c("libSDL3.dylib", "libSDL3.so", "libSDL3.so.0", "SDL3.dll")
+    )
+)
+
+if (length(sdl_info$unresolved.symbols)) {
+    stop("unresolved SDL3 symbols: ", paste(sdl_info$unresolved.symbols, collapse = ", "), call. = FALSE)
+}
+
+run_sdl_demo <- function() {
+    if (!isTRUE(sdl$SDL_Init(SDL_INIT_VIDEO))) {
+        stop("SDL_Init failed: ", sdl$SDL_GetError(), call. = FALSE)
+    }
+    on.exit(sdl$SDL_Quit(), add = TRUE)
+
+    window <- sdl$SDL_CreateWindow("rdyncall SDL3 demo", 640L, 360L, 0)
+    if (is.null(window) || is.nullptr(window)) {
+        stop("SDL_CreateWindow failed: ", sdl$SDL_GetError(), call. = FALSE)
+    }
+    on.exit(sdl$SDL_DestroyWindow(window), add = TRUE)
+
+    cat("SDL3 window created; closing in 1.5 seconds.\n")
+    sdl$SDL_Delay(1500L)
+}
+
+run_sdl_demo()

--- a/demo/libxml2.R
+++ b/demo/libxml2.R
@@ -1,0 +1,93 @@
+# Package: rdyncall
+# File: demo/libxml2.R
+# Description: XML parsing via direct libxml2 calls, compared with xml2 when available.
+
+load_rdyncall <- function() {
+    if ("package:rdyncall" %in% search()) {
+        return(invisible(TRUE))
+    }
+    lib.loc <- Sys.getenv("RDYNCALL_LIB", unset = "")
+    if (nzchar(lib.loc)) {
+        return(library("rdyncall", lib.loc = lib.loc, character.only = TRUE))
+    }
+    file <- ""
+    for (frame in rev(sys.frames())) {
+        if (!is.null(frame$ofile)) {
+            file <- normalizePath(frame$ofile, mustWork = FALSE)
+            break
+        }
+    }
+    if (nzchar(file)) {
+        lib.loc <- dirname(dirname(dirname(file)))
+        if (file.exists(file.path(lib.loc, "rdyncall"))) {
+            return(library("rdyncall", lib.loc = lib.loc, character.only = TRUE))
+        }
+    }
+    library("rdyncall", character.only = TRUE)
+}
+
+load_rdyncall()
+
+xml <- new.env(parent = globalenv())
+dynbind(
+    c("xml2", "xml2-2", "libxml2-2", "libxml2"),
+    paste(
+        "xmlReaderForMemory(ZiZZi)p",
+        "xmlTextReaderRead(p)i",
+        "xmlTextReaderNodeType(p)i",
+        "xmlTextReaderConstValue(p)Z",
+        "xmlFreeTextReader(p)v",
+        "xmlCleanupParser()v",
+        sep = ";"
+    ),
+    envir = xml
+)
+
+XML_READER_TYPE_TEXT <- 3L
+XML_READER_TYPE_CDATA <- 4L
+
+xml_text <- "<root><message>rdyncall libxml2 demo</message></root>"
+expected <- "rdyncall libxml2 demo"
+
+libxml2_text <- function(text) {
+    reader <- xml$xmlReaderForMemory(text, nchar(text, type = "bytes"), "memory.xml", NULL, 0L)
+    if (is.null(reader) || is.nullptr(reader)) {
+        stop("xmlReaderForMemory failed", call. = FALSE)
+    }
+    on.exit(xml$xmlFreeTextReader(reader), add = TRUE)
+
+    values <- character()
+    repeat {
+        status <- xml$xmlTextReaderRead(reader)
+        if (status == 0L) {
+            break
+        }
+        if (status < 0L) {
+            stop("xmlTextReaderRead failed", call. = FALSE)
+        }
+        node_type <- xml$xmlTextReaderNodeType(reader)
+        if (node_type %in% c(XML_READER_TYPE_TEXT, XML_READER_TYPE_CDATA)) {
+            values <- c(values, xml$xmlTextReaderConstValue(reader))
+        }
+    }
+
+    paste(values, collapse = "")
+}
+
+run_libxml2_demo <- function() {
+    on.exit(xml$xmlCleanupParser(), add = TRUE)
+
+    via_libxml2 <- libxml2_text(xml_text)
+    cat("libxml2: ", via_libxml2, "\n", sep = "")
+    stopifnot(identical(expected, via_libxml2))
+
+    if (requireNamespace("xml2", quietly = TRUE)) {
+        via_xml2 <- xml2::xml_text(xml2::read_xml(xml_text))
+        cat("xml2:    ", via_xml2, "\n", sep = "")
+        stopifnot(identical(expected, via_xml2))
+    } else {
+        cat("xml2 package not installed; comparison skipped.\n")
+    }
+}
+
+run_libxml2_demo()

--- a/demo/raylib.R
+++ b/demo/raylib.R
@@ -1,0 +1,169 @@
+# Package: rdyncall
+# File: demo/raylib.R
+# Description: raylib window demo using aggregate Color arguments.
+
+load_rdyncall <- function() {
+    if ("package:rdyncall" %in% search()) {
+        return(invisible(TRUE))
+    }
+    lib.loc <- Sys.getenv("RDYNCALL_LIB", unset = "")
+    if (nzchar(lib.loc)) {
+        return(library("rdyncall", lib.loc = lib.loc, character.only = TRUE))
+    }
+    file <- ""
+    for (frame in rev(sys.frames())) {
+        if (!is.null(frame$ofile)) {
+            file <- normalizePath(frame$ofile, mustWork = FALSE)
+            break
+        }
+    }
+    if (nzchar(file)) {
+        lib.loc <- dirname(dirname(dirname(file)))
+        if (file.exists(file.path(lib.loc, "rdyncall"))) {
+            return(library("rdyncall", lib.loc = lib.loc, character.only = TRUE))
+        }
+    }
+    library("rdyncall", character.only = TRUE)
+}
+
+load_rdyncall()
+
+source(system.file("demo-support", "github-release.R", package = "rdyncall", mustWork = TRUE), local = TRUE)
+
+raylib_asset_pattern <- function() {
+    sys <- Sys.info()[["sysname"]]
+    arch <- tolower(paste(R.version$arch, Sys.info()[["machine"]]))
+
+    if (identical(sys, "Darwin")) {
+        "macos"
+    } else if (identical(sys, "Linux")) {
+        if (grepl("aarch64|arm64", arch)) {
+            "linux_arm64"
+        } else if (grepl("i386|i686|x86", arch) && !grepl("x86_64|amd64", arch)) {
+            "linux_i386"
+        } else {
+            "linux_amd64"
+        }
+    } else if (.Platform$OS.type == "windows") {
+        if (grepl("arm64|aarch64", arch)) {
+            "winarm64_msvc"
+        } else if (grepl("i386|i686|x86", arch) && !grepl("x86_64|amd64", arch)) {
+            "win32_msvc"
+        } else {
+            "win64_msvc"
+        }
+    } else {
+        stop("raylib demo does not know which release asset to use for this platform", call. = FALSE)
+    }
+}
+
+find_raylib <- function() {
+    env_path <- Sys.getenv("RAYLIB_LIB", unset = "")
+    if (nzchar(env_path)) {
+        if (!file.exists(env_path)) {
+            stop("RAYLIB_LIB does not exist: ", env_path, call. = FALSE)
+        }
+        return(env_path)
+    }
+
+    cache_dir <- Sys.getenv("RDYNCALL_RAYLIB_CACHE", unset = "")
+    if (!nzchar(cache_dir)) {
+        cache_dir <- NULL
+    }
+
+    rdyncall_demo_download_github_library(
+        repo = "raysan5/raylib",
+        asset_pattern = raylib_asset_pattern(),
+        cache_name = "raylib",
+        exclude_pattern = "webassembly",
+        preferred_libraries = c("libraylib.dylib", "libraylib.so", "raylib.dll"),
+        cache_dir = cache_dir
+    )
+}
+
+bind_symbols <- function(lib, signatures) {
+    env <- new.env(parent = globalenv())
+    entries <- strsplit(gsub("[ \n\t]*", "", signatures), ";", fixed = TRUE)[[1L]]
+    entries <- entries[nzchar(entries)]
+
+    for (entry in entries) {
+        name <- sub("\\(.*$", "", entry)
+        signature <- sub("^[^(]+\\(", "", entry)
+        address <- dynsym(lib, name)
+        if (is.null(address)) {
+            stop("unresolved raylib symbol: ", name, call. = FALSE)
+        }
+        f <- function(...) NULL
+        body(f) <- substitute(dyncall(address, signature, ...), list(address = address, signature = signature))
+        environment(f) <- env
+        assign(name, f, envir = env)
+    }
+    env
+}
+
+cstruct("Color{CCCC}r g b a;")
+
+color <- function(r, g, b, a = 255L) {
+    x <- cdata(Color)
+    x$r <- as.integer(r)
+    x$g <- as.integer(g)
+    x$b <- as.integer(b)
+    x$a <- as.integer(a)
+    x
+}
+
+run_raylib_demo <- function() {
+    raylib_path <- find_raylib()
+    raylib <- dynload(raylib_path)
+    if (is.null(raylib)) {
+        stop("unable to load raylib library: ", raylib_path, call. = FALSE)
+    }
+
+    ray <- bind_symbols(
+        raylib,
+        paste(
+            "InitWindow(iiZ)v",
+            "CloseWindow()v",
+            "WindowShouldClose()B",
+            "BeginDrawing()v",
+            "EndDrawing()v",
+            "ClearBackground(<Color>)v",
+            "DrawText(Ziii<Color>)v",
+            "SetTargetFPS(i)v",
+            sep = ";"
+        )
+    )
+
+    probe_only <- tolower(Sys.getenv("RAYLIB_DEMO_PROBE_ONLY", "false")) %in% c("1", "true", "yes")
+    if (probe_only) {
+        invisible(color(230L, 41L, 55L, 255L))
+        cat("raylib probe ok: loaded ", raylib_path, "\n", sep = "")
+        return(invisible(TRUE))
+    }
+
+    duration <- as.numeric(Sys.getenv("RAYLIB_DEMO_SECONDS", "2"))
+    if (!is.finite(duration) || duration <= 0) {
+        duration <- 2
+    }
+
+    ray$InitWindow(640L, 360L, "rdyncall raylib demo")
+    on.exit(ray$CloseWindow(), add = TRUE)
+    ray$SetTargetFPS(60L)
+
+    background <- color(245L, 245L, 245L, 255L)
+    text_color <- color(80L, 80L, 80L, 255L)
+    accent <- color(230L, 41L, 55L, 255L)
+    started <- proc.time()[["elapsed"]]
+
+    while (!isTRUE(ray$WindowShouldClose()) && proc.time()[["elapsed"]] - started < duration) {
+        ray$BeginDrawing()
+        ray$ClearBackground(background)
+        ray$DrawText("rdyncall + raylib", 190L, 145L, 28L, accent)
+        ray$DrawText("Color is passed by value", 184L, 185L, 18L, text_color)
+        ray$EndDrawing()
+    }
+
+    cat("raylib window closed after ", round(proc.time()[["elapsed"]] - started, 2), " seconds.\n", sep = "")
+}
+
+run_raylib_demo()

--- a/inst/demo-support/github-release.R
+++ b/inst/demo-support/github-release.R
@@ -1,0 +1,130 @@
+# Shared helpers for demos that can download optional third-party libraries.
+
+rdyncall_demo_cache_root <- function() {
+    if (getRversion() >= "4.0.0") {
+        return(tools::R_user_dir("rdyncall", "cache"))
+    }
+
+    cache <- Sys.getenv("R_USER_CACHE_DIR", "")
+    if (nzchar(cache)) {
+        return(file.path(cache, "rdyncall"))
+    }
+
+    cache <- Sys.getenv("XDG_CACHE_HOME", "")
+    if (nzchar(cache)) {
+        return(file.path(cache, "rdyncall"))
+    }
+
+    if (.Platform$OS.type == "windows") {
+        cache <- Sys.getenv("LOCALAPPDATA", "")
+        if (!nzchar(cache)) {
+            cache <- tempdir()
+        }
+        return(file.path(cache, "rdyncall", "cache"))
+    }
+
+    home <- path.expand("~")
+    if (identical(Sys.info()[["sysname"]], "Darwin")) {
+        return(file.path(home, "Library", "Caches", "rdyncall"))
+    }
+
+    file.path(home, ".cache", "rdyncall")
+}
+
+rdyncall_demo_dynamic_libraries <- function(paths) {
+    paths[file.exists(paths) & grepl("(\\.dylib$|\\.so(\\.[0-9]+)*$|\\.dll$)", paths)]
+}
+
+rdyncall_demo_preferred_library <- function(paths, preferred = character()) {
+    libs <- rdyncall_demo_dynamic_libraries(paths)
+    if (!length(libs)) {
+        return(character())
+    }
+    if (length(preferred)) {
+        matched <- libs[basename(libs) %in% preferred]
+        if (length(matched)) {
+            return(matched[[1L]])
+        }
+    }
+    libs[[1L]]
+}
+
+rdyncall_demo_cached_github_library <- function(cache_dir, preferred = character()) {
+    if (!dir.exists(cache_dir)) {
+        return(character())
+    }
+    rdyncall_demo_preferred_library(
+        list.files(cache_dir, recursive = TRUE, full.names = TRUE),
+        preferred = preferred
+    )
+}
+
+rdyncall_demo_github_latest_assets <- function(repo) {
+    api <- paste0("https://api.github.com/repos/", repo, "/releases/latest")
+    json_file <- tempfile("rdyncall-github-release-", fileext = ".json")
+    utils::download.file(api, json_file, mode = "wb", quiet = TRUE)
+    json <- paste(readLines(json_file, warn = FALSE), collapse = "\n")
+
+    tag <- sub('.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*', "\\1", json)
+    if (identical(tag, json)) {
+        tag <- "latest"
+    }
+
+    matches <- regmatches(json, gregexpr('"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"', json))[[1L]]
+    urls <- sub('^"browser_download_url"[[:space:]]*:[[:space:]]*"([^"]+)".*$', "\\1", matches)
+    list(tag = tag, urls = urls)
+}
+
+rdyncall_demo_download_github_library <- function(repo, asset_pattern, cache_name,
+                                                  exclude_pattern = NULL,
+                                                  preferred_libraries = character(),
+                                                  cache_dir = NULL) {
+    if (is.null(cache_dir)) {
+        cache_dir <- file.path(rdyncall_demo_cache_root(), cache_name)
+    }
+
+    cached <- rdyncall_demo_cached_github_library(cache_dir, preferred = preferred_libraries)
+    if (length(cached)) {
+        message("Using cached ", cache_name, " library: ", cached)
+        return(cached)
+    }
+
+    release <- rdyncall_demo_github_latest_assets(repo)
+    urls <- release$urls[grepl(asset_pattern, release$urls, ignore.case = TRUE)]
+    if (!is.null(exclude_pattern)) {
+        urls <- urls[!grepl(exclude_pattern, urls, ignore.case = TRUE)]
+    }
+    if (!length(urls)) {
+        stop("no GitHub release asset matched this platform pattern: ", asset_pattern, call. = FALSE)
+    }
+
+    version_dir <- file.path(cache_dir, release$tag)
+    dir.create(version_dir, recursive = TRUE, showWarnings = FALSE)
+
+    archive <- file.path(version_dir, basename(urls[[1L]]))
+    if (!file.exists(archive)) {
+        message("Downloading ", cache_name, " ", release$tag, " to ", archive)
+        utils::download.file(urls[[1L]], archive, mode = "wb")
+    } else {
+        message("Using cached ", cache_name, " archive: ", archive)
+    }
+
+    extract_dir <- file.path(version_dir, "extract")
+    if (!dir.exists(extract_dir)) {
+        dir.create(extract_dir, recursive = TRUE)
+        if (grepl("\\.zip$", archive, ignore.case = TRUE)) {
+            utils::unzip(archive, exdir = extract_dir)
+        } else {
+            utils::untar(archive, exdir = extract_dir)
+        }
+    }
+
+    lib <- rdyncall_demo_preferred_library(
+        list.files(extract_dir, recursive = TRUE, full.names = TRUE),
+        preferred = preferred_libraries
+    )
+    if (!length(lib)) {
+        stop("downloaded GitHub release asset did not contain a dynamic library", call. = FALSE)
+    }
+    lib
+}


### PR DESCRIPTION
## Summary
- Migrate the main SDL demo from the old SDL 1.2/OpenGL cube example to a focused SDL3 window lifecycle demo.
- Add a `demo/libxml2.R` example that calls libxml2 directly with the reader API and compares the parsed text with the `xml2` package when available.
- Add `demo/raylib.R` as the raylib aggregate-by-value demo, using a shared GitHub release downloader installed under `inst/demo-support/`.
- Keep demo downloads out of the source tree by default with a small R 3.x-compatible cache helper.

## Changes
- `inst/demo-support/github-release.R` provides a reusable helper for optional demo libraries distributed through GitHub Releases.
- The helper uses `tools::R_user_dir()` on R >= 4.0 and an independent minimal cache-root fallback on older R versions.
- `raylib` honors `RAYLIB_LIB` for an explicit local library path; otherwise it downloads the latest matching release asset once and reuses the cached library.
- `RDYNCALL_RAYLIB_CACHE` remains available as an explicit cache override for local testing or CI-like probes.
- `RAYLIB_DEMO_PROBE_ONLY=true` provides a non-GUI verification path for terminals where `InitWindow()` may block.
- SDL3 remains an optional local dependency; the demo reports a clear `SDL3_LIB` hint when no SDL3 shared library is discoverable.

## Out of scope
- The demos are still manual examples; CRAN checks do not run GUI demos.
- This PR does not add a new public downloader API.
- This PR does not change `dynbind()` to accept already-loaded library handles.

## Checks Run
- `Rscript --vanilla -e 'files <- c("inst/demo-support/github-release.R", "demo/raylib.R", "demo/SDL.R", "demo/libxml2.R"); invisible(lapply(files, parse)); cat("parse ok\n")'`
- `Rscript --vanilla -e 'source("inst/demo-support/github-release.R"); cat(rdyncall_demo_cache_root(), "\n", sep = "")'`
- `R CMD INSTALL --preclean --no-test-load --library=/private/tmp/rdyncall-demo-lib .`
- `RDYNCALL_LIB=/private/tmp/rdyncall-demo-lib RDYNCALL_RAYLIB_CACHE=/Users/hongyuanjia/Library/CloudStorage/SynologyDrive-Personal/repos/rdyncall/tools/.cache/raylib RAYLIB_DEMO_PROBE_ONLY=true Rscript --vanilla -e 'demo("raylib", package = "rdyncall", lib.loc = "/private/tmp/rdyncall-demo-lib")'`
- `R CMD build --no-build-vignettes .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes rdyncall_0.9.0.9000.tar.gz`
- `git diff --check`
