### PR TITLE
feat: generate disk dynport packages

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -27,7 +27,7 @@ export(
 # --- utils_float.R ----------------------------------------------------------
   floatraw, as.floatraw, floatraw2numeric,
 # --- dynport.R --------------------------------------------------------------
-  dynport
+  dynport, dynport_install_package, dynport_load_into, dynport_lib
 )
 # --- dynstruct.R ------------------------------------------------------------
 S3method("$<-", struct)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Update the bundled dyncall source and stop tracking generated static libraries.
 - Replace deprecated/internal R C API usage with public accessors where possible.
 - Support `dynlist()` for macOS dyld shared cache libraries.
+- Generate real on-disk R packages from DCF DynPort files via `dynport()`.
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.
 - Store aggregate field names in the explicit `typeinfo$fields$name` column.
 - Add `struct` and `union` bitfield layout, access, DynPort parsing, and by-value aggregate support.

--- a/R/dynport.R
+++ b/R/dynport.R
@@ -1,9 +1,8 @@
 #' Dynamic R Bindings to standard and common C libraries
 #'
 #' @description
-#' Function to bind APIs of standard and common C libraries to R via dynamically
-#' created interface environment objects comprising R wrappers for C functions,
-#' object-like macros, enums and data types.
+#' Functions to turn DCF DynPort files into generated R packages that provide
+#' wrappers for C functions, object-like macros, enums and data types.
 #'
 #' @details
 #' `dynport()` offers a convenient method for binding entire C libraries to R.
@@ -15,57 +14,24 @@
 #' See [rdyncall-demos] for OS-specific installation notes for several C
 #' libraries.
 #'
-#' The binding method is data-driven using platform-portable specifications
-#' named _DynPort_ files.
-#' _DynPort_ files are stored in a repository that is installed as part of the
-#' package installation. They are generated using the \pkg{porter} package.
-#' When `dynport()` processes a _DynPort_ file given by `portname`, an
-#' environment object is created, populated with R wrapper and helper objects
-#' that make up the interface to the C library, and attached to the search path
-#' with the name `dynport:<PORTNAME>`.
-#' Unloading of previously loaded dynport environments is achieved via
-#' `detach(dynport:<PORTNAME>)`.
+#' The binding method is data-driven using platform-portable specifications named
+#' _DynPort_ files. The current implementation supports DCF (Debian Control File)
+#' `.dynport` files.
 #'
-#' Up to \pkg{rdyncall} version 0.7.4, R name space objects were used as
-#' containers as described in the article _Foreign Library Interface_, thus
-#' dynport \sQuote{packages} appeared as `"package:<PORTNAME>"` on the
-#' search path.
-#' The mechanism to create synthesized R packages at run-time required the use
-#' of `.Internal` calls.
-#' But since the use of internal R functions is not permitted for packages
-#' distributed on CRAN we downgraded the package to use ordinary environment
-#' objects starting with version 0.7.5 until a public interface for the creation
-#' of R namespace objects is available.
+#' When `dynport()` processes a _DynPort_ file, it generates and installs a real
+#' R package whose namespace is populated at load time from the DynPort metadata.
+#' By default, generated package names use the prefix given by option
+#' `rdyncall.dynport.package.prefix`, which defaults to `"dyn."`. For example,
+#' a DynPort with `Package: SDL2` is installed as `dyn.SDL2` unless a package
+#' name is explicitly supplied.
 #'
-#' The following gives a list of currently available _DynPorts_:
+#' The following gives a list of currently supported DCF _DynPorts_:
 #'
 #' | **DynPort name/C library** | **Description**                                 |
 #' |:---------------------------|:------------------------------------------------|
-#' | `expat`                    | Expat XML Parser Library                        |
-#' | `GL`                       | OpenGL 1.1 API                                  |
-#' | `GLU`                      | OpenGL Utility Library                          |
-#' | `GLUT`                     | OpenGL Utility Toolkit Library                  |
-#' | `SDL`                      | Simple DirectMedia Layer Library                |
-#' | `SDL_image`                | Loading of image files (png, jpeg, ...)         |
-#' | `SDL_mixer`                | Loading/Playing of ogg/mp3/mod music files.     |
-#' | `SDL_ttf`                  | Loading/Rendering of True Type Fonts.           |
-#' | `SDL_net`                  | Networking library.                             |
-#' | `glew`                     | OpenGL Extension Wrangler (includes OpenGL 3.0) |
-#' | `glfw`                     | OpenGL Windowing/Setup Library                  |
-#' | `gl3`                      | strict OpenGL 3 (untested)                      |
-#' | `R`                        | R shared library                                |
-#' | `ode`                      | Open Dynamics (Physics-) Engine (untested)      |
-#' | `cuda`                     | NVIDIA Cuda (untested)                          |
-#' | `csound`                   | Sound programming language and library          |
-#' | `opencl`                   | OpenCL (untested)                               |
-#' | `stdio`                    | C Standard Library I/O Functions                |
-#' | `glpk`                     | GNU Linear Programming Kit                      |
-#' | `EGL`                      | Embedded Systems Graphics Library               |
+#' | `SDL2`                     | Simple DirectMedia Layer 2                      |
 #'
-#' As of the current implementation _DynPort_ files are DCF (Debian Control File)
-#' files which follow the same rules for R package `DESCRIPTION` files.
-#'
-#' The format records the following binding metadata:
+#' The DCF format records the following binding metadata:
 #'
 #' - Functions (and pointer-to-function variables) are mapped via [dynbind()]
 #'   and a description of the C library using a _library signatures_.
@@ -78,23 +44,51 @@
 #' This would refer to `"<repo>/<portname>.dynport"` where `repo` usually refers
 #' to the initial _DynPort_ repository located at the sub-folder `"dynports/"`
 #' of the package.
-#' If `portfile` is given, then this value is taken as file path (usually for
-#' testing purpose).
+#' If `portfile` is given, then this value is taken as file path.
 #'
 #' A tool suite, comprising AWK (was boost wave), GCC Preprocessor, GCC-XML and
 #' XSLT, was used to generate the available _DynPort_ files automatically
 #' by extracting type information from C library header files.
 #'
-#' In a future release, the DynPort format will be changed to
-#' a language-neutral text file document.
-#'
 #' @param portname the name of a dynport, given as a literal or character
-#'        string. It will be used as the namespace name.
+#'        string.
 #'
-#' @param portfile `NULL` or character string giving a script file to parse.
+#' @param portfile `NULL` or character string giving a DCF `.dynport` file to
+#'        parse.
 #'
 #' @param repo character string giving the path to the root of the `dynport`
 #'        repository.
+#'
+#' @param package `NULL` or character string giving the generated R package name.
+#'        When `NULL`, the `Package` field from the DynPort file is prefixed by
+#'        option `rdyncall.dynport.package.prefix`.
+#'
+#' @param lib character string giving the R library path where the generated
+#'        package is installed. Defaults to `dynport_lib()`.
+#'
+#' @param rebuild logical. If `TRUE`, reinstall an existing generated package
+#'        when the DynPort file contents have changed.
+#'
+#' @param load logical. If `TRUE`, load and attach the generated package in the
+#'        current R session after installation.
+#'
+#' @param quiet logical. If `TRUE`, suppress installation and loading output
+#'        where possible.
+#'
+#' @param create logical. If `TRUE`, create the default DynPort package library
+#'        when it does not exist.
+#'
+#' @param add logical. If `TRUE`, prepend the DynPort package library to
+#'        `.libPaths()`.
+#'
+#' @param envir environment to populate from a DynPort file.
+#'
+#' @return
+#' `dynport()` invisibly returns the generated package name.
+#' `dynport_install_package()` invisibly returns the installed package path with
+#' the generated package name stored in attribute `"package"`.
+#' `dynport_load_into()` invisibly returns `envir`.
+#' `dynport_lib()` returns the DynPort package library path.
 #'
 #' @references
 #'
@@ -121,32 +115,28 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Using SDL and OpenGL in R
-#' dynport(SDL)
-#' dynport(GL)
-#' # Initialize Video Sub-system
-#' SDL_Init(SDL_INIT_VIDEO)
-#' # Initialize Screen with OpenGL Context and Double Buffering
-#' SDL_SetVideoMode(320, 256, 32, SDL_OPENGL+SDL_DOUBLEBUF)
-#' # Clear Color and Clear Screen
-#' glClearColor(0, 0, 1, 0) # blue
-#' glClear(GL_COLOR_BUFFER_BIT)
-#' # Flip Double-Buffer
-#' SDL_GL_SwapBuffers()
+#' dynport(SDL2)
+#' dyn.SDL2::SDL_GetPlatform()
 #' }
-#' @aliases loadDynportNamespace
+#' @aliases dynport_install_package dynport_load_into dynport_lib
 #' @keywords programming interface
 #' @author Daniel Adler <dadler@uni-goettingen.de>
 #' @export
-dynport <- function(portname, portfile = NULL, repo = system.file("dynports", package = "rdyncall")) {
+dynport <- function(portname, portfile = NULL, repo = system.file("dynports", package = "rdyncall"),
+                    package = NULL, lib = dynport_lib(), rebuild = FALSE,
+                    load = TRUE, quiet = FALSE) {
     # literate portname string
     portname <- as.character(substitute(portname))
-    if (missing(portfile)) {
+    if (is.null(portfile)) {
         # search for portfile
         portfile <- file.path(repo, paste(portname, ".dynport", sep = ""))
         if (!file.exists(portfile)) stop("dynport '", portname, "' not found.")
     }
-    loadDynportNamespace(portname, portfile)
+    installed <- dynport_install_package_impl(
+        portname, portfile = portfile, repo = repo, package = package, lib = lib,
+        rebuild = rebuild, load = load, quiet = quiet
+    )
+    invisible(attr(installed, "package"))
 }
 
 # ref: {r-lib/desc:::read_dcf()}
@@ -208,7 +198,7 @@ dynport_read <- function(file) {
     })
 
     # check both 'Enum' and 'Enum/...'
-    if ("Enum" %in% keys && grepl("^Enum", keys)) {
+    if ("Enum" %in% keys && any(grepl("^Enum/.+", keys))) {
         stop("Both 'Enum' and 'Enum/...' found. Should have either one.", call. = FALSE)
     }
 
@@ -513,7 +503,6 @@ dynport_parse_struct_union <- function(value, lnum = 1L, envir = parent.frame(),
             }
         }
 
-        # parse field types
         parsed <- dynport_parse_types(kind, tail[[1L]], envir, layout = field_layout$layout)
         dynport_issue_type_error(parsed, tail[[1L]], issue_error, name)
 
@@ -632,58 +621,431 @@ dynport_issue_error <- function(type, name, lnums, values, reason) {
     ), call. = FALSE)
 }
 
-loadDynportNamespace <- function(name, portfile, do.attach = TRUE) {
-    name <- as.character(name)
-    portfile <- as.character(portfile)
+#' @rdname dynport
+#' @export
+dynport_install_package <- function(portname, portfile = NULL,
+                                    repo = system.file("dynports", package = "rdyncall"),
+                                    package = NULL, lib = dynport_lib(), rebuild = FALSE,
+                                    load = FALSE, quiet = FALSE) {
+    dynport_install_package_impl(
+        as.character(substitute(portname)), portfile = portfile, repo = repo,
+        package = package, lib = lib, rebuild = rebuild, load = load,
+        quiet = quiet
+    )
+}
+
+dynport_install_package_impl <- function(portname, portfile = NULL, repo, package = NULL,
+                                         lib = dynport_lib(), rebuild = FALSE,
+                                         load = FALSE, quiet = FALSE) {
+    portfile <- dynport_resolve_portfile(portname, portfile, repo)
     port <- dynport_read(portfile)
-    if (do.attach) {
-        envname <- paste("dynport", name, sep = ":")
-        if (envname %in% search()) {
-            return()
-        }
-        env <- new.env()
-        sys.source(portfile, envir = env)
-
-        # directly use base::attach will cause a CRAN check NOTE
-        getExportedValue(.BaseNamespaceEnv, "attach")(env, name = envname)
-    } else {
-        env <- new.env()
-        sys.source(portfile, envir = env)
-        return(env)
+    if (is.null(port)) {
+        stop("Empty 'dynport' file.", call. = FALSE)
     }
+
+    package <- dynport_package_name(port, package)
+    md5 <- dynport_md5(portfile)
+    lib <- dynport_lib_path(lib, create = TRUE)
+
+    skip_install <- dynport_prepare_install(package, lib, md5, rebuild)
+    if (!skip_install) {
+        src <- dynport_create_package_source(port, portfile, portname, package, md5)
+        on.exit(unlink(src, recursive = TRUE, force = TRUE), add = TRUE)
+        dynport_install_source(src, lib, quiet = quiet)
+    }
+
+    path <- normalizePath(file.path(lib, package), "/", mustWork = FALSE)
+    if (load) {
+        dynport_load_package(package, lib, quiet = quiet)
+    }
+
+    attr(path, "package") <- package
+    invisible(path)
 }
 
-makeNamespace <- function(name, version = NULL, lib = NULL) {
-    impenv <- new.env(parent = .BaseNamespaceEnv, hash = TRUE)
-    attr(impenv, "name") <- paste("imports", name, sep = ":")
-    env <- new.env(parent = impenv, hash = TRUE)
-    name <- as.character(as.name(name))
-    version <- as.character(version)
-    info <- new.env(hash = TRUE, parent = baseenv())
-    assign(".__NAMESPACE__.", info, envir = env)
-    assign("spec", c(name = name, version = version), envir = info)
-    setNamespaceInfo(env, "exports", new.env(hash = TRUE, parent = baseenv()))
-    dimpenv <- new.env(parent = baseenv(), hash = TRUE)
-    attr(dimpenv, "name") <- paste("lazydata", name, sep = ":")
-    setNamespaceInfo(env, "lazydata", dimpenv)
-    setNamespaceInfo(env, "imports", list(base = TRUE))
-    setNamespaceInfo(env, "path", normalizePath(file.path(lib, name), "/", TRUE))
-    setNamespaceInfo(env, "dynlibs", NULL)
-    setNamespaceInfo(env, "S3methods", matrix(NA_character_, 0L, 3L))
-    assign(".__S3MethodsTable__.", new.env(hash = TRUE, parent = baseenv()), envir = env)
-    eval(as.call(list(quote(.Internal), quote(registerNamespace(name, env)))))
-    env
+#' @rdname dynport
+#' @export
+dynport_load_into <- function(portfile, envir) {
+    if (!is.environment(envir)) {
+        stop("'envir' must be an environment.", call. = FALSE)
+    }
+
+    port <- dynport_read(portfile)
+    if (is.null(port)) {
+        stop("Empty 'dynport' file.", call. = FALSE)
+    }
+
+    dynport_validate_export_names(dynport_export_names(port))
+    dynport_assign_typeinfos(port[["Struct"]], envir)
+    dynport_assign_typeinfos(port[["Union"]], envir)
+    dynport_assign_enums(port[["Enum"]], envir)
+    dynport_assign_functions(port, "Function", envir, funcptr = FALSE)
+    dynport_assign_functions(port, "FuncPtr", envir, funcptr = TRUE)
+
+    invisible(envir)
 }
 
-env2namespace <- function(name, version, env, lib = NULL) {
-    env <- force(env)
-    ns <- makeNamespace(name, version, lib)
-    exports <- getNamespaceInfo(ns, "exports")
-    objects <- ls(env, all.names = TRUE)
-    lapply(objects, function(nm) {
-        assign(nm, get(nm, env, inherits = FALSE), ns)
-        assign(nm, nm, exports)
-    })
+#' @rdname dynport
+#' @export
+dynport_lib <- function(create = TRUE, add = FALSE) {
+    lib <- getOption("rdyncall.dynport.lib", NULL)
+    if (is.null(lib)) {
+        cache <- if (exists("R_user_dir", envir = asNamespace("tools"), mode = "function")) {
+            tools::R_user_dir("rdyncall", "cache")
+        } else {
+            file.path(path.expand("~"), ".cache", "R", "rdyncall")
+        }
+        lib <- file.path(cache, "dynports", paste0("R-", as.character(getRversion())))
+    }
+
+    lib <- dynport_lib_path(lib, create = create)
+    if (add) {
+        .libPaths(unique(c(lib, normalizePath(.libPaths(), "/", mustWork = FALSE))))
+    }
+    lib
+}
+
+dynport_resolve_portfile <- function(portname, portfile = NULL, repo) {
+    if (is.null(portfile)) {
+        portfile <- file.path(repo, paste0(portname, ".dynport"))
+    }
+    portfile <- path.expand(as.character(portfile))
+    if (length(portfile) != 1L || is.na(portfile) || !nzchar(portfile)) {
+        stop("'portfile' must be a single non-empty path.", call. = FALSE)
+    }
+    if (!file.exists(portfile)) {
+        stop("dynport '", portname, "' not found.", call. = FALSE)
+    }
+    normalizePath(portfile, "/", mustWork = TRUE)
+}
+
+dynport_lib_path <- function(lib, create = TRUE) {
+    lib <- path.expand(as.character(lib))
+    if (length(lib) != 1L || is.na(lib) || !nzchar(lib)) {
+        stop("'lib' must be a single non-empty path.", call. = FALSE)
+    }
+    if (create && !dir.exists(lib)) {
+        dir.create(lib, recursive = TRUE, showWarnings = FALSE)
+    }
+    if (create && !dir.exists(lib)) {
+        stop("Failed to create dynport package library '", lib, "'.", call. = FALSE)
+    }
+    normalizePath(lib, "/", mustWork = create)
+}
+
+dynport_package_name <- function(port, package = NULL) {
+    base <- if (!is.null(port[["Package"]])) {
+        as.character(port[["Package"]])
+    } else {
+        NULL
+    }
+    if (is.null(base) || !nzchar(base)) {
+        stop("The 'dynport' file must define a non-empty 'Package' field.", call. = FALSE)
+    }
+
+    if (is.null(package)) {
+        prefix <- getOption("rdyncall.dynport.package.prefix", "dyn.")
+        package <- paste0(prefix, base)
+    }
+    dynport_validate_package_name(package)
+    package
+}
+
+dynport_validate_package_name <- function(package) {
+    package <- as.character(package)
+    if (length(package) != 1L || is.na(package) || !nzchar(package)) {
+        stop("'package' must be a single non-empty string.", call. = FALSE)
+    }
+    if (!grepl("^[A-Za-z][A-Za-z0-9.]*$", package) || grepl("\\.$", package)) {
+        stop("Invalid package name '", package, "'.", call. = FALSE)
+    }
+    invisible(package)
+}
+
+dynport_export_names <- function(port) {
+    exports <- character()
+    exports <- c(exports, names(port[["Function"]]))
+    exports <- c(exports, names(port[["FuncPtr"]]))
+    exports <- c(exports, names(port[["Struct"]]))
+    exports <- c(exports, names(port[["Union"]]))
+
+    enums <- port[["Enum"]]
+    if (!is.null(enums)) {
+        exports <- c(exports, names(enums))
+        exports <- c(exports, unlist(lapply(enums, base::names), use.names = FALSE))
+    }
+
+    dynport_validate_export_names(exports)
+}
+
+dynport_validate_export_names <- function(names) {
+    names <- names[nzchar(names)]
+    invalid <- names != make.names(names)
+    if (any(invalid)) {
+        stop("Invalid export names found in 'dynport' file: ",
+            paste(sQuote(names[invalid]), collapse = ", "),
+            call. = FALSE
+        )
+    }
+    duplicates <- unique(names[duplicated(names)])
+    if (length(duplicates)) {
+        stop("Duplicate export names found in 'dynport' file: ",
+            paste(sQuote(duplicates), collapse = ", "),
+            call. = FALSE
+        )
+    }
+    names
+}
+
+dynport_assign_typeinfos <- function(objects, envir) {
+    if (!length(objects)) return(invisible())
+    for (nm in names(objects)) {
+        assign(nm, objects[[nm]], envir = envir)
+    }
+    invisible()
+}
+
+dynport_assign_enums <- function(enums, envir) {
+    if (!length(enums)) return(invisible())
+    for (nm in names(enums)) {
+        vals <- enums[[nm]]
+        assign(nm, vals, envir = envir)
+        if (length(vals)) {
+            list2env(as.list(vals), envir = envir)
+        }
+    }
+    invisible()
+}
+
+dynport_assign_functions <- function(port, field, envir, funcptr = FALSE) {
+    functions <- port[[field]]
+    if (!length(functions)) return(invisible())
+
+    libraries <- port[["Library"]]
+    if (!length(libraries)) {
+        stop("The 'dynport' file must define 'Library' before binding functions.", call. = FALSE)
+    }
+
+    report <- dynbind(
+        libraries, dynport_compact_signature(functions),
+        envir = envir, funcptr = funcptr
+    )
+    dynport_assign_unresolved(report$unresolved.symbols, envir)
+    invisible(report)
+}
+
+dynport_compact_signature <- function(functions) {
+    paste0(vapply(functions, function(x) {
+        paste0(x$name, "(", x$argument$sig, ")", x$return, ";")
+    }, character(1L)), collapse = "\n")
+}
+
+dynport_assign_unresolved <- function(symbols, envir) {
+    for (symbol in symbols) {
+        f <- local({
+            unresolved <- symbol
+            function(...) {
+                stop("Unresolved DynPort symbol '", unresolved, "'.", call. = FALSE)
+            }
+        })
+        environment(f) <- envir
+        assign(symbol, f, envir = envir)
+    }
+    invisible()
+}
+
+dynport_md5 <- function(file) {
+    unname(tools::md5sum(file))
+}
+
+dynport_prepare_install <- function(package, lib, md5, rebuild = FALSE) {
+    loaded <- package %in% loadedNamespaces()
+    if (loaded) {
+        loaded_info <- dynport_package_description(getNamespaceInfo(getNamespace(package), "path"))
+        if (!dynport_is_generated_package(loaded_info)) {
+            stop("Package '", package, "' is already loaded and was not generated by rdyncall.",
+                call. = FALSE
+            )
+        }
+        if (!identical(dynport_description_value(loaded_info, "Config/rdyncall/dynport-md5"), md5)) {
+            if (!rebuild) {
+                stop("Generated dynport package '", package,
+                    "' is already loaded with different contents; use rebuild = TRUE.",
+                    call. = FALSE
+                )
+            }
+            dynport_unload_package(package)
+        }
+    }
+
+    installed <- dynport_package_description(file.path(lib, package))
+    if (is.null(installed)) {
+        return(FALSE)
+    }
+    if (!dynport_is_generated_package(installed)) {
+        stop("Package '", package, "' is already installed in '", lib,
+            "' and was not generated by rdyncall.", call. = FALSE
+        )
+    }
+
+    installed_md5 <- dynport_description_value(installed, "Config/rdyncall/dynport-md5")
+    if (identical(installed_md5, md5)) {
+        return(TRUE)
+    }
+    if (!rebuild) {
+        stop("Generated dynport package '", package,
+            "' is already installed with different contents; use rebuild = TRUE.",
+            call. = FALSE
+        )
+    }
+
+    if (package %in% loadedNamespaces()) {
+        dynport_unload_package(package)
+    }
+    unlink(file.path(lib, package), recursive = TRUE, force = TRUE)
+    FALSE
+}
+
+dynport_unload_package <- function(package) {
+    search_name <- paste0("package:", package)
+    if (search_name %in% search()) {
+        detach(search_name, character.only = TRUE)
+    }
+    if (package %in% loadedNamespaces()) {
+        tryCatch(
+            unloadNamespace(package),
+            error = function(e) {
+                stop("Failed to unload generated dynport package '", package,
+                    "'. Restart R and try again. Details: ", conditionMessage(e),
+                    call. = FALSE
+                )
+            }
+        )
+    }
+    invisible()
+}
+
+dynport_package_description <- function(path) {
+    desc <- file.path(path, "DESCRIPTION")
+    if (!file.exists(desc)) return(NULL)
+    as.list(read.dcf(desc)[1L, ])
+}
+
+dynport_description_value <- function(desc, field) {
+    if (is.null(desc)) return(NULL)
+    value <- desc[[field]]
+    if (is.null(value) || is.na(value)) NULL else value
+}
+
+dynport_is_generated_package <- function(desc) {
+    isTRUE(identical(dynport_description_value(desc, "Config/rdyncall/generated"), "true"))
+}
+
+dynport_create_package_source <- function(port, portfile, portname, package, md5) {
+    src <- tempfile(paste0(package, "-"))
+    dir.create(src, recursive = TRUE, showWarnings = FALSE)
+    dir.create(file.path(src, "R"), recursive = TRUE)
+    dir.create(file.path(src, "inst", "dynports"), recursive = TRUE)
+
+    dynport_basename <- basename(portfile)
+    file.copy(portfile, file.path(src, "inst", "dynports", dynport_basename), overwrite = TRUE)
+    dynport_write_description(src, port, portname, package, dynport_basename, md5)
+    dynport_write_namespace(src, dynport_export_names(port))
+    dynport_write_loader(src, dynport_basename)
+    dynport_write_license(src)
+    src
+}
+
+dynport_write_description <- function(src, port, portname, package, dynport_file, md5) {
+    dynport_package <- as.character(port[["Package"]])
+    dynport_version <- if (is.null(port[["Version"]])) "0.0.0" else as.character(port[["Version"]])
+    rdyncall_version <- tryCatch(
+        as.character(utils::packageVersion("rdyncall")),
+        error = function(e) "0.0.0"
+    )
+    desc <- data.frame(
+        check.names = FALSE,
+        Package = package,
+        Type = "Package",
+        Title = paste("DynPort Bindings for", dynport_package),
+        Version = dynport_version,
+        Author = "Generated by rdyncall",
+        Maintainer = "rdyncall DynPort generator <noreply@example.com>",
+        Description = paste("Generated rdyncall DynPort wrapper package for", dynport_package, "bindings."),
+        License = "file LICENSE",
+        Encoding = "UTF-8",
+        Imports = "rdyncall",
+        `Config/rdyncall/generated` = "true",
+        `Config/rdyncall/dynport-portname` = portname,
+        `Config/rdyncall/dynport-package` = dynport_package,
+        `Config/rdyncall/dynport-version` = dynport_version,
+        `Config/rdyncall/dynport-file` = dynport_file,
+        `Config/rdyncall/dynport-md5` = md5,
+        `Config/rdyncall/rdyncall-version` = rdyncall_version
+    )
+    write.dcf(desc, file = file.path(src, "DESCRIPTION"))
+}
+
+dynport_write_namespace <- function(src, exports) {
+    lines <- if (length(exports)) paste0("export(", exports, ")") else character()
+    writeLines(lines, file.path(src, "NAMESPACE"), useBytes = TRUE)
+}
+
+dynport_write_loader <- function(src, dynport_file) {
+    lines <- c(
+        ".onLoad <- function(libname, pkgname) {",
+        sprintf("    portfile <- system.file(\"dynports\", %s, package = pkgname, mustWork = TRUE)", deparse(dynport_file)),
+        "    rdyncall::dynport_load_into(portfile, envir = parent.env(environment()))",
+        "}"
+    )
+    writeLines(lines, file.path(src, "R", "zzz.R"), useBytes = TRUE)
+}
+
+dynport_write_license <- function(src) {
+    writeLines(c(
+        "This package was generated by rdyncall from a DynPort specification.",
+        "",
+        "Permission to use, copy, modify, and/or distribute this generated package",
+        "for any purpose with or without fee is hereby granted, provided that this",
+        "permission notice appears in all copies.",
+        "",
+        "THE GENERATED PACKAGE IS PROVIDED \"AS IS\" AND WITHOUT ANY WARRANTY."
+    ), file.path(src, "LICENSE"), useBytes = TRUE)
+}
+
+dynport_install_source <- function(src, lib, quiet = FALSE) {
+    args <- c("CMD", "INSTALL", "--no-test-load", "-l", shQuote(lib), shQuote(src))
+    env <- paste0("R_LIBS=", paste(unique(c(lib, .libPaths())), collapse = .Platform$path.sep))
+    if (quiet) {
+        out <- system2(file.path(R.home("bin"), "R"), args, stdout = TRUE, stderr = TRUE, env = env)
+        status <- attr(out, "status")
+        if (is.null(status)) status <- 0L
+        if (status != 0L) {
+            stop("Failed to install generated dynport package:\n",
+                paste(out, collapse = "\n"), call. = FALSE
+            )
+        }
+    } else {
+        status <- system2(file.path(R.home("bin"), "R"), args, env = env)
+        if (status != 0L) {
+            stop("Failed to install generated dynport package.", call. = FALSE)
+        }
+    }
+    invisible()
+}
+
+dynport_load_package <- function(package, lib, quiet = FALSE) {
+    lib <- dynport_lib_path(lib, create = TRUE)
+    if (!lib %in% normalizePath(.libPaths(), "/", mustWork = FALSE)) {
+        .libPaths(unique(c(lib, normalizePath(.libPaths(), "/", mustWork = FALSE))))
+    }
+    if (paste0("package:", package) %in% search()) {
+        return(invisible(TRUE))
+    }
+    library(package = package, character.only = TRUE, lib.loc = lib,
+        quietly = quiet, warn.conflicts = !quiet
+    )
+    invisible(TRUE)
 }
 
 split_lines <- function(x, trim = TRUE) {

--- a/R/rdyncall-package.R
+++ b/R/rdyncall-package.R
@@ -1,5 +1,4 @@
 #' Improved Foreign Function Interface (FFI) and Dynamic Bindings to C Libraries
-#' (e.g. OpenGL)
 #'
 #' @description
 #' The package provides a cross-platform framework for dynamic binding of C
@@ -8,9 +7,8 @@
 #' symbolic access to foreign C struct/union data types and wrapping of R
 #' functions as C callback function pointers.
 #' Dynamic bindings to shared C libraries are data-driven by cross-platform
-#' binding specification using a compact plain text format; an initial
-#' repository of bindings to a couple of common C libraries (OpenGL, SDL, Expat,
-#' glew, CUDA, OpenCL, ODE, R) comes with the package.
+#' DynPort specifications. The current `dynport()` implementation supports DCF
+#' `.dynport` files and generates real R packages from them.
 #' The package includes a variety of technology demos and OS-specific notes for
 #' installation of shared libraries.
 #'
@@ -94,44 +92,8 @@
 #'
 #' @examples
 #' \dontrun{
-#' # multimedia example
-#' # load dynports for OpenGL, Simple DirectMedia library
-#' # globals:
-#' surface <- NULL
-#' # init SDL and OpenGL
-#' init <- function()
-#' {
-#'     dynport(SDL)
-#'     dynport(GL)
-#'     if ( SDL_Init(SDL_INIT_VIDEO) != 0 ) stop("SDL_Init failed")
-#'     surface <<- SDL_SetVideoMode(320,240,32,SDL_DOUBLEBUF+SDL_OPENGL)
-#'     cat("surface dimension:", surface$w, "x",surface$h,sep="")
-#' }
-#' # draw blue screen
-#' updateSurface <- function(t)
-#' {
-#'     glClearColor(0,0,t \%\% 1,0)
-#'     glClear(GL_COLOR_BUFFER_BIT+GL_DEPTH_BUFFER_BIT)
-#'     SDL_GL_SwapBuffers()
-#' }
-#' # wait till close
-#' mainloop <- function()
-#' {
-#'     quit <- FALSE
-#'     evt <- cdata(SDL_Event)
-#'     base <- SDL_GetTicks() / 1000
-#'     t <- 0
-#'     while(!quit) {
-#'         updateSurface(t)
-#'         while(SDL_PollEvent(evt)) {
-#'             if ( evt$type == SDL_QUIT ) quit <- TRUE
-#'         }
-#'         now <- SDL_GetTicks() / 1000
-#'         t <- now - base
-#'     }
-#' }
-#' init()
-#' mainloop()
+#' dynport(SDL2)
+#' dyn.SDL2::SDL_GetPlatform()
 #' }
 #' @keywords internal
 "_PACKAGE"

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ The intended audience for this package are developers experienced with C, that
 Brief Tour 1/2: Dynamic R Bindings to C Libraries
 -------------------------------------------------
 
-The dynamic binding interface consists of a single function, similar to
-'library' or 'require':
+The dynamic binding interface consists of a single function:
 
 ```r
 dynport(portname)
@@ -70,32 +69,18 @@ dynport(portname)
 
 portname refers to a 'DynPort' file name that represents an R binding to a
 common C interface and library.
-The function the above has the side effect of attaching a newly created R name
-space, populated with thin R helper objects to C entities of the underlying
-C library:
+The function above generates, installs, and loads a small R package populated
+with thin R helper objects to C entities of the underlying C library:
 
   - call wrapper to C functions
   - symbolic constants of C macros and enums,
   - type information objects for C struct and union data types.
 
-The package contains a repository of the following DynPort files:
+The package currently contains the following DCF DynPort file:
 
   | Port Name   | Description of C Shared Library/API              |
   | ------------|------------------------------------------------- |
-  | expat       | Expat XML Parser Library                         |
-  | GL          | OpenGL 1.1 API                                   |
-  | GLU         | OpenGL Utility Library                           |
-  | SDL         | Simple DirectMedia Layer library                 |
-  | SDL_image   | Loading of image files (png,jpeg..)              |
-  | SDL_mixer   | Loading/Playing of ogg/mp3/mod music files.      |
-  | SDL_ttf     | Loading/Rendering of True Type Fonts.            |
-  | glew        | OpenGL Extension Wrangler (includes OpenGL 3.0)  |
-  | gl3         | strict OpenGL 3 (untested)                       |
-  | R           | R shared library                                 |
-  | ode         | Open Dynamics (Physics-) Engine (untested)       |
-  | cuda        | NVIDIA Cuda (untested)                           |
-  | opencl      | OpenCL (untested)                                |
-  | stdio       | C Standard Library I/O Functions                 |
+  | SDL2        | Simple DirectMedia Layer 2                       |
 
 In order to use a DynPort on a host system, the shared C libraries
 need to be installed first.
@@ -107,32 +92,12 @@ collected for a large range of operating-systems and OS distributions.
 Since the rdyncall package is alredy ported across major R platforms, code
 that uses a DynPort can run cross-platform without compilation.
 
-Here is a small example for using the SDL and OpenGL for multimedia/3D:
+Here is a small SDL2 example:
 
 ```r
-# load SDL and OpenGL bindings
-dynport(SDL)
-dynport(GL)
-
-# initialize video sub-system
-SDL_Init(SDL_INIT_VIDEO)
-
-# open double-buffered OpenGL window surface
-surface <- SDL_SetVideoMode(640,480,32,SDL_OPENGL+SDL_DOUBLEBUF)
-
-# print dimension by accessing fields external C pointer to struct SDL_Surface
-print( paste("dimenstion:", surface$w, "x", surface$h ))
-
-# clear buffer
-glClearColor(0.3,0.6,0.8,0)
-glClear(GL_COLOR_BUFFER_BIT)
-
-# update display
-SDL_GL_SwapBuffers()
+dynport(SDL2)
+dyn.SDL2::SDL_GetPlatform()
 ```
-
-A more detailed version including user-interface handling is available
-in `demo(SDL)`.
 
 ## Brief Tour 2/2: Alternative FFI via 'dyncall'
 

--- a/inst/tinytest/test_dynport.R
+++ b/inst/tinytest/test_dynport.R
@@ -1,7 +1,23 @@
 expect_dynport_portfile_error <- function(lines, pattern) {
     portfile <- tempfile(fileext = ".dynport")
     writeLines(lines, portfile)
-    expect_error(dynport(rdyncall_invalid_dynport, portfile = portfile), pattern)
+    expect_error(rdyncall:::dynport_read(portfile), pattern)
+}
+
+write_dynport <- function(lines) {
+    portfile <- tempfile(fileext = ".dynport")
+    writeLines(lines, portfile)
+    portfile
+}
+
+unload_test_package <- function(package) {
+    search_name <- paste0("package:", package)
+    if (search_name %in% search()) {
+        detach(search_name, character.only = TRUE)
+    }
+    if (package %in% loadedNamespaces()) {
+        unloadNamespace(package)
+    }
 }
 
 env <- new.env()
@@ -23,29 +39,20 @@ expect_dynport_portfile_error("Package: a-", "ASCII")
 expect_dynport_portfile_error(c("Package: a", "  b"), "single string")
 expect_dynport_portfile_error("Package: a", "two character")
 expect_dynport_portfile_error("Package: .a", "letter")
-expect_dynport_portfile_error("Package:", "unexpected")
-expect_dynport_portfile_error("Package: SDL2", "object 'Package'")
 
 # version
 expect_dynport_portfile_error("Version: -", "specification")
 expect_dynport_portfile_error(c("Version: 1", "  2"), "single string")
-expect_dynport_portfile_error("Version:", "unexpected")
-expect_dynport_portfile_error("Version: 2.1", "object 'Version'")
 
 # library
 expect_dynport_portfile_error(c("Library: com", " |.o"), "file name")
-expect_dynport_portfile_error(c("Library: a.o", " b"), "object 'Library'")
 
 # enum
-expect_dynport_portfile_error("Enum:  ", "Both")
-expect_dynport_portfile_error("Enum: a = 1", "Both")
+expect_dynport_portfile_error("Enum: a = 1", "Invalid specification")
 expect_dynport_portfile_error("Enum/test: a = 1 b = 2", "member specification")
 expect_dynport_portfile_error("Enum/test: a = 1.2", "member value")
-expect_dynport_portfile_error(c("Enum/test: a = 1", " b = 2"), "object 'Enum'")
 
 # struct
-expect_dynport_portfile_error(c("Struct:", "  "), "unexpected")
-expect_dynport_portfile_error("Struct:", "unexpected")
 expect_dynport_portfile_error(c("Struct: test", " }"), "\\{")
 expect_dynport_portfile_error(c("Struct: test{", " }}"), "\\}")
 expect_dynport_portfile_error("Struct: a = 1", "\\{")
@@ -57,7 +64,6 @@ expect_dynport_portfile_error("Struct: test{i} a b", "number")
 expect_dynport_portfile_error("Struct: test{d} a:1", "integer")
 expect_dynport_portfile_error("Struct: test{I} a:33", "exceeds")
 expect_dynport_portfile_error("Struct: test{I} a:0", "zero-width")
-expect_dynport_portfile_error("Struct: test{ii} a b", "unexpected")
 expect_dynport_portfile_error("Struct: test{C} c @pack(3)", "power-of-two")
 expect_dynport_portfile_error("Struct: test{C} c @packed @pack(1)", "duplicate")
 expect_dynport_portfile_error("Struct: test{C} c @bytepack", "unknown")
@@ -69,8 +75,6 @@ expect_equal(packed_struct$PackedDyn$align, 1L)
 expect_equal(packed_struct$PackedDyn$fields$offset, c(0L, 1L))
 
 # union
-expect_dynport_portfile_error(c("Union:", "  "), "unexpected")
-expect_dynport_portfile_error("Union:", "unexpected")
 expect_dynport_portfile_error(c("Union: test", " }"), "\\{")
 expect_dynport_portfile_error(c("Union: test{", " }}"), "\\}")
 expect_dynport_portfile_error("Union: a = 1", "\\{")
@@ -80,7 +84,6 @@ expect_dynport_portfile_error("Union: test{ab}", "type name")
 expect_dynport_portfile_error("Union: test{ii}a", "number")
 expect_dynport_portfile_error("Union: test{i} a b", "number")
 expect_dynport_portfile_error("Union: test{d} a:1", "integer")
-expect_dynport_portfile_error("Union: test{ii} a b", "unexpected")
 expect_dynport_portfile_error("Union: test{C} c @align(3)", "power-of-two")
 
 aligned_union <- rdyncall:::dynport_parse_union("AlignedDynUnion{Ci} c i @align(8);")
@@ -93,8 +96,6 @@ expect_equal(parsed_bits$Flags$fields$name, c("a", "b", "", "c"))
 expect_equal(parsed_bits$Flags$fields$bit_width, c(1L, 3L, 4L, 8L))
 
 # function
-expect_dynport_portfile_error(c("Function:", "  "), "unexpected")
-expect_dynport_portfile_error("Function:", "unexpected")
 expect_dynport_portfile_error(c("Function: test", " )"), "Invalid specification")
 expect_dynport_portfile_error(c("Function: test(", " ))"), "Extra")
 expect_dynport_portfile_error("Function: a = 1", "spec")
@@ -105,15 +106,126 @@ expect_dynport_portfile_error("Function: test(ii)a", "type name")
 expect_dynport_portfile_error("Function: test(C[2])v arg", "C\\[2\\].*argument")
 expect_dynport_portfile_error("Function: test(i) i a b", "number")
 expect_dynport_portfile_error("Function: test(ii)i a a", "name")
-expect_dynport_portfile_error("Function: test(ii)i a b", "unexpected")
 
 empty_port <- tempfile(fileext = ".dynport")
 expect_true(file.create(empty_port))
-empty_envname <- "dynport:rdyncall_empty_dynport"
-if (empty_envname %in% search()) {
-    detach(empty_envname, character.only = TRUE)
-}
-expect_silent(dynport(rdyncall_empty_dynport, portfile = empty_port))
-expect_true(empty_envname %in% search())
-detach(empty_envname, character.only = TRUE)
-expect_false(empty_envname %in% search())
+expect_error(dynport(rdyncall_empty_dynport, portfile = empty_port), "Empty")
+
+opaque <- rdyncall:::dynport_parse_struct("Opaque{};")
+expect_equal(opaque$Opaque$size, 0L)
+expect_equal(opaque$Opaque$align, 1L)
+expect_equal(nrow(opaque$Opaque$fields), 0L)
+
+sdl2_portfile <- system.file("dynports", "SDL2.dynport", package = "rdyncall", mustWork = TRUE)
+sdl2 <- rdyncall:::dynport_read(sdl2_portfile)
+expect_equal(as.character(sdl2$Package), "SDL2")
+expect_true("SDL_mutex" %in% names(sdl2$Struct))
+
+local({
+    portfile <- write_dynport(c(
+        "Package: TinyPort",
+        "Version: 1.0.0",
+        "Enum/TinyEnum:",
+        "    TINY_ONE=1",
+        "Struct:",
+        "    TinyOpaque{};"
+    ))
+    lib <- tempfile("rdyncall-dynport-lib")
+    package <- "dyn.TinyPort"
+    unload_test_package(package)
+    on.exit(unload_test_package(package), add = TRUE)
+
+    expect_silent(pkg <- dynport(tiny, portfile = portfile, lib = lib, quiet = TRUE))
+    expect_equal(pkg, package)
+    expect_true(dir.exists(file.path(lib, package)))
+    expect_true(package %in% loadedNamespaces())
+    expect_equal(getExportedValue(package, "TINY_ONE"), 1L)
+    expect_true("package:dyn.TinyPort" %in% search())
+})
+
+local({
+    portfile <- write_dynport(c(
+        "Package: PrefixPort",
+        "Version: 1.0.0",
+        "Enum/PrefixEnum:",
+        "    PREFIX_ONE=1"
+    ))
+    lib <- tempfile("rdyncall-dynport-lib")
+    old <- options(rdyncall.dynport.package.prefix = "zz.")
+    on.exit(options(old), add = TRUE)
+
+    path <- dynport_install_package(prefix, portfile = portfile, lib = lib, quiet = TRUE)
+    expect_true(dir.exists(file.path(lib, "zz.PrefixPort")))
+    expect_equal(attr(path, "package"), "zz.PrefixPort")
+
+    path <- dynport_install_package(prefix, portfile = portfile, package = "ShortPort", lib = lib, quiet = TRUE)
+    expect_true(dir.exists(file.path(lib, "ShortPort")))
+    expect_equal(attr(path, "package"), "ShortPort")
+})
+
+local({
+    portfile <- write_dynport(c(
+        "Package: ConflictPort",
+        "Version: 1.0.0",
+        "Enum/ConflictEnum:",
+        "    CONFLICT_ONE=1"
+    ))
+    lib <- tempfile("rdyncall-dynport-lib")
+    fake <- file.path(lib, "dyn.ConflictPort")
+    expect_true(dir.create(fake, recursive = TRUE))
+    writeLines(c(
+        "Package: dyn.ConflictPort",
+        "Version: 1.0.0",
+        "Title: Fake",
+        "Description: Fake package.",
+        "License: MIT"
+    ), file.path(fake, "DESCRIPTION"))
+    expect_error(
+        dynport_install_package(conflict, portfile = portfile, lib = lib, quiet = TRUE),
+        "not generated"
+    )
+})
+
+local({
+    portfile <- write_dynport(c(
+        "Package: RebuildPort",
+        "Version: 1.0.0",
+        "Enum/RebuildEnum:",
+        "    REBUILD_ONE=1"
+    ))
+    lib <- tempfile("rdyncall-dynport-lib")
+    expect_silent(dynport_install_package(rebuild, portfile = portfile, lib = lib, quiet = TRUE))
+    writeLines(c(
+        "Package: RebuildPort",
+        "Version: 1.0.0",
+        "Enum/RebuildEnum:",
+        "    REBUILD_ONE=2"
+    ), portfile)
+    expect_error(
+        dynport_install_package(rebuild, portfile = portfile, lib = lib, quiet = TRUE),
+        "rebuild = TRUE"
+    )
+    expect_silent(dynport_install_package(rebuild, portfile = portfile, lib = lib, rebuild = TRUE, quiet = TRUE))
+})
+
+local({
+    if (!is.null(dynfind(c("msvcrt", "c", "c.so.6")))) {
+        portfile <- write_dynport(c(
+            "Package: CString",
+            "Version: 1.0.0",
+            "Library:",
+            "    msvcrt",
+            "    c",
+            "    c.so.6",
+            "Function:",
+            "    strlen(Z)L str;"
+        ))
+        lib <- tempfile("rdyncall-dynport-lib")
+        package <- "dyn.CString"
+        unload_test_package(package)
+        on.exit(unload_test_package(package), add = TRUE)
+
+        expect_silent(dynport(cstring, portfile = portfile, lib = lib, quiet = TRUE))
+        expect_equal(getExportedValue(package, "strlen")("abc"), 3)
+    }
+})

--- a/man/dynport.Rd
+++ b/man/dynport.Rd
@@ -2,28 +2,81 @@
 % Please edit documentation in R/dynport.R
 \name{dynport}
 \alias{dynport}
-\alias{loadDynportNamespace}
+\alias{dynport_install_package}
+\alias{dynport_load_into}
+\alias{dynport_lib}
 \title{Dynamic R Bindings to standard and common C libraries}
 \usage{
 dynport(
   portname,
   portfile = NULL,
-  repo = system.file("dynports", package = "rdyncall")
+  repo = system.file("dynports", package = "rdyncall"),
+  package = NULL,
+  lib = dynport_lib(),
+  rebuild = FALSE,
+  load = TRUE,
+  quiet = FALSE
 )
+
+dynport_install_package(
+  portname,
+  portfile = NULL,
+  repo = system.file("dynports", package = "rdyncall"),
+  package = NULL,
+  lib = dynport_lib(),
+  rebuild = FALSE,
+  load = FALSE,
+  quiet = FALSE
+)
+
+dynport_load_into(portfile, envir)
+
+dynport_lib(create = TRUE, add = FALSE)
 }
 \arguments{
 \item{portname}{the name of a dynport, given as a literal or character
-string. It will be used as the namespace name.}
+string.}
 
-\item{portfile}{\code{NULL} or character string giving a script file to parse.}
+\item{portfile}{\code{NULL} or character string giving a DCF \code{.dynport} file to
+parse.}
 
 \item{repo}{character string giving the path to the root of the \code{dynport}
 repository.}
+
+\item{package}{\code{NULL} or character string giving the generated R package name.
+When \code{NULL}, the \code{Package} field from the DynPort file is prefixed by
+option \code{rdyncall.dynport.package.prefix}.}
+
+\item{lib}{character string giving the R library path where the generated
+package is installed. Defaults to \code{dynport_lib()}.}
+
+\item{rebuild}{logical. If \code{TRUE}, reinstall an existing generated package
+when the DynPort file contents have changed.}
+
+\item{load}{logical. If \code{TRUE}, load and attach the generated package in the
+current R session after installation.}
+
+\item{quiet}{logical. If \code{TRUE}, suppress installation and loading output
+where possible.}
+
+\item{envir}{environment to populate from a DynPort file.}
+
+\item{create}{logical. If \code{TRUE}, create the default DynPort package library
+when it does not exist.}
+
+\item{add}{logical. If \code{TRUE}, prepend the DynPort package library to
+\code{.libPaths()}.}
+}
+\value{
+\code{dynport()} invisibly returns the generated package name.
+\code{dynport_install_package()} invisibly returns the installed package path with
+the generated package name stored in attribute \code{"package"}.
+\code{dynport_load_into()} invisibly returns \code{envir}.
+\code{dynport_lib()} returns the DynPort package library path.
 }
 \description{
-Function to bind APIs of standard and common C libraries to R via dynamically
-created interface environment objects comprising R wrappers for C functions,
-object-like macros, enums and data types.
+Functions to turn DCF DynPort files into generated R packages that provide
+wrappers for C functions, object-like macros, enums and data types.
 }
 \details{
 \code{dynport()} offers a convenient method for binding entire C libraries to R.
@@ -35,57 +88,24 @@ manual installation.
 See \link{rdyncall-demos} for OS-specific installation notes for several C
 libraries.
 
-The binding method is data-driven using platform-portable specifications
-named \emph{DynPort} files.
-\emph{DynPort} files are stored in a repository that is installed as part of the
-package installation. They are generated using the \pkg{porter} package.
-When \code{dynport()} processes a \emph{DynPort} file given by \code{portname}, an
-environment object is created, populated with R wrapper and helper objects
-that make up the interface to the C library, and attached to the search path
-with the name \verb{dynport:<PORTNAME>}.
-Unloading of previously loaded dynport environments is achieved via
-\verb{detach(dynport:<PORTNAME>)}.
+The binding method is data-driven using platform-portable specifications named
+\emph{DynPort} files. The current implementation supports DCF (Debian Control File)
+\code{.dynport} files.
 
-Up to \pkg{rdyncall} version 0.7.4, R name space objects were used as
-containers as described in the article \emph{Foreign Library Interface}, thus
-dynport \sQuote{packages} appeared as \code{"package:<PORTNAME>"} on the
-search path.
-The mechanism to create synthesized R packages at run-time required the use
-of \code{.Internal} calls.
-But since the use of internal R functions is not permitted for packages
-distributed on CRAN we downgraded the package to use ordinary environment
-objects starting with version 0.7.5 until a public interface for the creation
-of R namespace objects is available.
+When \code{dynport()} processes a \emph{DynPort} file, it generates and installs a real
+R package whose namespace is populated at load time from the DynPort metadata.
+By default, generated package names use the prefix given by option
+\code{rdyncall.dynport.package.prefix}, which defaults to \code{"dyn."}. For example,
+a DynPort with \code{Package: SDL2} is installed as \code{dyn.SDL2} unless a package
+name is explicitly supplied.
 
-The following gives a list of currently available \emph{DynPorts}:\tabular{ll}{
+The following gives a list of currently supported DCF \emph{DynPorts}:\tabular{ll}{
    \strong{DynPort name/C library} \tab \strong{Description} \cr
-   \code{expat} \tab Expat XML Parser Library \cr
-   \code{GL} \tab OpenGL 1.1 API \cr
-   \code{GLU} \tab OpenGL Utility Library \cr
-   \code{GLUT} \tab OpenGL Utility Toolkit Library \cr
-   \code{SDL} \tab Simple DirectMedia Layer Library \cr
-   \code{SDL_image} \tab Loading of image files (png, jpeg, ...) \cr
-   \code{SDL_mixer} \tab Loading/Playing of ogg/mp3/mod music files. \cr
-   \code{SDL_ttf} \tab Loading/Rendering of True Type Fonts. \cr
-   \code{SDL_net} \tab Networking library. \cr
-   \code{glew} \tab OpenGL Extension Wrangler (includes OpenGL 3.0) \cr
-   \code{glfw} \tab OpenGL Windowing/Setup Library \cr
-   \code{gl3} \tab strict OpenGL 3 (untested) \cr
-   \code{R} \tab R shared library \cr
-   \code{ode} \tab Open Dynamics (Physics-) Engine (untested) \cr
-   \code{cuda} \tab NVIDIA Cuda (untested) \cr
-   \code{csound} \tab Sound programming language and library \cr
-   \code{opencl} \tab OpenCL (untested) \cr
-   \code{stdio} \tab C Standard Library I/O Functions \cr
-   \code{glpk} \tab GNU Linear Programming Kit \cr
-   \code{EGL} \tab Embedded Systems Graphics Library \cr
+   \code{SDL2} \tab Simple DirectMedia Layer 2 \cr
 }
 
 
-As of the current implementation \emph{DynPort} files are DCF (Debian Control File)
-files which follow the same rules for R package \code{DESCRIPTION} files.
-
-The format records the following binding metadata:
+The DCF format records the following binding metadata:
 \itemize{
 \item Functions (and pointer-to-function variables) are mapped via \code{\link[=dynbind]{dynbind()}}
 and a description of the C library using a \emph{library signatures}.
@@ -99,30 +119,16 @@ The file path to the \emph{DynPort} file is derived from \code{portname} per def
 This would refer to \code{"<repo>/<portname>.dynport"} where \code{repo} usually refers
 to the initial \emph{DynPort} repository located at the sub-folder \code{"dynports/"}
 of the package.
-If \code{portfile} is given, then this value is taken as file path (usually for
-testing purpose).
+If \code{portfile} is given, then this value is taken as file path.
 
 A tool suite, comprising AWK (was boost wave), GCC Preprocessor, GCC-XML and
 XSLT, was used to generate the available \emph{DynPort} files automatically
 by extracting type information from C library header files.
-
-In a future release, the DynPort format will be changed to
-a language-neutral text file document.
 }
 \examples{
 \dontrun{
-# Using SDL and OpenGL in R
-dynport(SDL)
-dynport(GL)
-# Initialize Video Sub-system
-SDL_Init(SDL_INIT_VIDEO)
-# Initialize Screen with OpenGL Context and Double Buffering
-SDL_SetVideoMode(320, 256, 32, SDL_OPENGL+SDL_DOUBLEBUF)
-# Clear Color and Clear Screen
-glClearColor(0, 0, 1, 0) # blue
-glClear(GL_COLOR_BUFFER_BIT)
-# Flip Double-Buffer
-SDL_GL_SwapBuffers()
+dynport(SDL2)
+dyn.SDL2::SDL_GetPlatform()
 }
 }
 \references{

--- a/man/rdyncall-package.Rd
+++ b/man/rdyncall-package.Rd
@@ -4,8 +4,7 @@
 \name{rdyncall-package}
 \alias{rdyncall}
 \alias{rdyncall-package}
-\title{Improved Foreign Function Interface (FFI) and Dynamic Bindings to C Libraries
-(e.g. OpenGL)}
+\title{Improved Foreign Function Interface (FFI) and Dynamic Bindings to C Libraries}
 \description{
 The package provides a cross-platform framework for dynamic binding of C
 libraries using a flexible Foreign Function Interface (FFI).
@@ -13,9 +12,8 @@ The FFI supports almost all fundamental C types, multiple calling conventions,
 symbolic access to foreign C struct/union data types and wrapping of R
 functions as C callback function pointers.
 Dynamic bindings to shared C libraries are data-driven by cross-platform
-binding specification using a compact plain text format; an initial
-repository of bindings to a couple of common C libraries (OpenGL, SDL, Expat,
-glew, CUDA, OpenCL, ODE, R) comes with the package.
+DynPort specifications. The current \code{dynport()} implementation supports DCF
+\code{.dynport} files and generates real R packages from them.
 The package includes a variety of technology demos and OS-specific notes for
 installation of shared libraries.
 }
@@ -92,44 +90,8 @@ The R Package has been tested on several major R platforms.
 
 \examples{
 \dontrun{
-# multimedia example
-# load dynports for OpenGL, Simple DirectMedia library
-# globals:
-surface <- NULL
-# init SDL and OpenGL
-init <- function()
-{
-    dynport(SDL)
-    dynport(GL)
-    if ( SDL_Init(SDL_INIT_VIDEO) != 0 ) stop("SDL_Init failed")
-    surface <<- SDL_SetVideoMode(320,240,32,SDL_DOUBLEBUF+SDL_OPENGL)
-    cat("surface dimension:", surface$w, "x",surface$h,sep="")
-}
-# draw blue screen
-updateSurface <- function(t)
-{
-    glClearColor(0,0,t \\%\\% 1,0)
-    glClear(GL_COLOR_BUFFER_BIT+GL_DEPTH_BUFFER_BIT)
-    SDL_GL_SwapBuffers()
-}
-# wait till close
-mainloop <- function()
-{
-    quit <- FALSE
-    evt <- cdata(SDL_Event)
-    base <- SDL_GetTicks() / 1000
-    t <- 0
-    while(!quit) {
-        updateSurface(t)
-        while(SDL_PollEvent(evt)) {
-            if ( evt$type == SDL_QUIT ) quit <- TRUE
-        }
-        now <- SDL_GetTicks() / 1000
-        t <- now - base
-    }
-}
-init()
-mainloop()
+dynport(SDL2)
+dyn.SDL2::SDL_GetPlatform()
 }
 }
 \references{


### PR DESCRIPTION
## Summary

Closes #27.

This changes `dynport()` to turn DCF DynPort files into real generated R packages, install them into an rdyncall-managed library, and load them into the current session. The branch has been checked with `devtools::document()`, installed-package tinytest coverage, `git diff --check`, and `devtools::check()`; the full check completed with 0 errors, with the local environment reporting a missing `checkbashisms` script plus existing NOTE-class environment/package-structure findings.

## Changes

- Add `dynport_install_package()`, `dynport_load_into()`, and `dynport_lib()`.
- Generate minimal package sources with `DESCRIPTION`, exact `NAMESPACE` exports, `.onLoad()` metadata loading, a generated-package license, and the source `.dynport` under `inst/dynports/`.
- Use prefixed generated package names by default via `rdyncall.dynport.package.prefix`, while allowing explicit `package =`.
- Detect non-generated package conflicts, checksum mismatches, and rebuild requirements.
- Populate generated package namespaces from parsed functions, function pointers, structs, unions, enum vectors, and enum constants.
- Support opaque struct/union layouts with zero fields.
- Update roxygen docs, README examples, NEWS, and focused tinytest coverage.

## Out of scope

- Converting the historical `.R` DynPort files.
- Implementing in-session virtual namespaces or internal namespace registration.
- Reworking old demos that still refer to historical DynPort names.
