### PR TITLE
feat: accept dynbind library paths and handles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - Replace deprecated/internal R C API usage with public accessors where possible.
 - Support `dynlist()` for macOS dyld shared cache libraries.
 - Generate real on-disk R packages from DCF DynPort files via `dynport()`.
+- Allow `dynbind()` to accept direct library paths and existing external
+  pointer handles in addition to short library names.
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.
 - Store aggregate field names in the explicit `typeinfo$fields$name` column.
 - Add `struct` and `union` bitfield layout, access, DynPort parsing, and by-value aggregate support.

--- a/R/dynbind.R
+++ b/R/dynbind.R
@@ -29,8 +29,10 @@
 #' `"glAccum(If)v ; glClear(I)v ; glClearColor(ffff)v ;"`
 #' ```
 #'
-#' Symbolic names are resolved using the library specified by `libnames`
-#' using [dynfind()] for loading.
+#' Symbolic names are resolved using the library specified by `libnames`.
+#' Character short library names are loaded using [dynfind()], character paths
+#' are loaded directly using [dynload()], and external pointer handles returned
+#' by [dynload()] or [dynfind()] are used as-is.
 #' For each function, a thin call wrapper function is created using the
 #' following template:
 #'
@@ -56,9 +58,12 @@
 #' `<TARGET>` is replaced with the expression `unpack(<TARGET>,"p",0)` in order
 #' to dereference `<TARGET>` as a pointer-to-function variable at call-time.
 #'
-#' @param libnames vector of character strings giving short library names of the
-#'        shared library to be loaded. See [dynfind()] for details.
-#'        `
+#' @param libnames character vector or external pointer handle specifying the
+#'        shared library. Character values that contain a path separator, or
+#'        name an existing file, are passed directly to [dynload()]. Other
+#'        character values are treated as short library names and loaded using
+#'        [dynfind()]. External pointer handles returned by [dynload()] or
+#'        [dynfind()] are used directly.
 #' @param signature character string specifying the *library signature* that
 #'        determines the set of foreign function names and types. See details.
 #'
@@ -107,13 +112,14 @@
 # TODO: use named character vector for signatures?
 dynbind <- function(libnames, signature, envir = parent.frame(), callmode = "default", pattern = NULL, replace = NULL, funcptr = FALSE) {
     # load shared library
-    libh <- dynfind(libnames)
+    libh <- dynbind_resolve_libhandle(libnames)
     if (is.null(libh)) {
-        cat("dynbind error: Unable to find shared library '", libnames[[1L]], "'.\n", sep = "")
+        liblabel <- dynbind_libnames_label(libnames)
+        cat("dynbind error: Unable to find shared library '", liblabel, "'.\n", sep = "")
         cat("For details how to install dynport shared libs, type: ?'rdyncall-demos' might help.\n")
         cat("If there is no information about your OS, consult the projects page how to build and install the shared library for your operating-system.\n")
         cat("Make sure the shared library can be found at the default system places or adjust environment variables (e.g. %PATH% or $LD_LIBRARY_PATH).\n")
-        stop("unable to find shared library '", libnames[[1]], "'.\n", call. = FALSE)
+        stop("unable to find shared library '", liblabel, "'.\n", call. = FALSE)
     }
 
     # -- convert library signature to signature table
@@ -166,4 +172,44 @@ dynbind <- function(libnames, signature, envir = parent.frame(), callmode = "def
         list(libhandle = libh, unresolved.symbols = syms.failed),
         class = "dynbind.report"
     )
+}
+
+dynbind_resolve_libhandle <- function(libnames) {
+    if (is.externalptr(libnames)) {
+        if (!dynload_is_handle(libnames)) {
+            stop("libnames external pointer must be returned by dynload() or dynfind()", call. = FALSE)
+        }
+        return(libnames)
+    }
+
+    if (!is.character(libnames)) {
+        stop("libnames must be a character vector or external pointer handle", call. = FALSE)
+    }
+
+    for (libname in libnames) {
+        handle <- if (dynbind_is_library_path(libname)) {
+            dynload(libname)
+        } else {
+            dynfind(libname)
+        }
+        if (!is.null(handle)) {
+            return(handle)
+        }
+    }
+
+    NULL
+}
+
+dynbind_is_library_path <- function(libname) {
+    !is.na(libname) && (grepl("[/\\\\]", libname) || file.exists(libname))
+}
+
+dynbind_libnames_label <- function(libnames) {
+    if (is.externalptr(libnames)) {
+        return("<external pointer>")
+    }
+    if (length(libnames)) {
+        return(libnames[[1L]])
+    }
+    "<empty>"
 }

--- a/R/dynload.R
+++ b/R/dynload.R
@@ -225,6 +225,10 @@ dynload <- function(libname, auto.unload = TRUE) {
     libh
 }
 
+dynload_is_handle <- function(libhandle) {
+    .Call("C_is_dynload_handle", libhandle, PACKAGE = "rdyncall")
+}
+
 #' @rdname dynload
 #' @export
 dynunload <- function(libhandle) {

--- a/inst/tinytest/dynbind.c
+++ b/inst/tinytest/dynbind.c
@@ -1,0 +1,4 @@
+int rdyncall_dynbind_add(int x, int y)
+{
+    return x + y;
+}

--- a/inst/tinytest/test_dynbind.R
+++ b/inst/tinytest/test_dynbind.R
@@ -7,3 +7,53 @@ expect_equal(
     "dynbind.report"
 )
 expect_true(exists("c_qsort", env, inherits = FALSE))
+
+build_dynbind_fixture <- function() {
+    src <- system.file("tinytest", "dynbind.c", package = "rdyncall", mustWork = TRUE)
+    src <- normalizePath(src, winslash = "/", mustWork = TRUE)
+    outdir <- tempfile("rdyncall-dynbind-fixture-")
+    dir.create(outdir)
+    outdir <- normalizePath(outdir, winslash = "/", mustWork = TRUE)
+    lib <- file.path(outdir, paste0("dynbind", .Platform$dynlib.ext))
+    out <- system2(file.path(R.home("bin"), "R"),
+        c("CMD", "SHLIB", "-o", lib, src),
+        stdout = TRUE, stderr = TRUE
+    )
+    if (!is.null(attr(out, "status"))) {
+        stop(paste(c("failed to build dynbind test fixture", out), collapse = "\n"), call. = FALSE)
+    }
+    lib
+}
+
+expect_dynbind_add <- function(libnames) {
+    env <- new.env()
+    bind <- dynbind(
+        libnames,
+        "rdyncall_dynbind_add(ii)i;",
+        pattern = "^rdyncall_dynbind_", replace = "", envir = env
+    )
+    expect_equal(class(bind), "dynbind.report")
+    expect_true(exists("add", env, inherits = FALSE))
+    expect_equal(env$add(2L, 3L), 5L)
+    bind
+}
+
+fixture <- build_dynbind_fixture()
+
+expect_dynbind_add(fixture)
+
+local({
+    oldwd <- setwd(dirname(fixture))
+    on.exit(setwd(oldwd), add = TRUE)
+    expect_dynbind_add(file.path(".", basename(fixture)))
+})
+
+handle <- dynload(fixture)
+attr(handle, "dynbind-test") <- "input-handle"
+bind <- expect_dynbind_add(handle)
+expect_equal(attr(bind$libhandle, "dynbind-test"), "input-handle")
+
+expect_error(
+    dynbind(as.externalptr(1), "rdyncall_dynbind_add(ii)i;"),
+    "external pointer must be returned by dynload"
+)

--- a/man/dynbind.Rd
+++ b/man/dynbind.Rd
@@ -15,9 +15,12 @@ dynbind(
 )
 }
 \arguments{
-\item{libnames}{vector of character strings giving short library names of the
-shared library to be loaded. See \code{\link[=dynfind]{dynfind()}} for details.
-`}
+\item{libnames}{character vector or external pointer handle specifying the
+shared library. Character values that contain a path separator, or
+name an existing file, are passed directly to \code{\link[=dynload]{dynload()}}. Other
+character values are treated as short library names and loaded using
+\code{\link[=dynfind]{dynfind()}}. External pointer handles returned by \code{\link[=dynload]{dynload()}} or
+\code{\link[=dynfind]{dynfind()}} are used directly.}
 
 \item{signature}{character string specifying the \emph{library signature} that
 determines the set of foreign function names and types. See details.}
@@ -77,8 +80,10 @@ library:
 \if{html}{\out{<div class="sourceCode">}}\preformatted{`"glAccum(If)v ; glClear(I)v ; glClearColor(ffff)v ;"`
 }\if{html}{\out{</div>}}
 
-Symbolic names are resolved using the library specified by \code{libnames}
-using \code{\link[=dynfind]{dynfind()}} for loading.
+Symbolic names are resolved using the library specified by \code{libnames}.
+Character short library names are loaded using \code{\link[=dynfind]{dynfind()}}, character paths
+are loaded directly using \code{\link[=dynload]{dynload()}}, and external pointer handles returned
+by \code{\link[=dynload]{dynload()}} or \code{\link[=dynfind]{dynfind()}} are used as-is.
 For each function, a thin call wrapper function is created using the
 following template:
 

--- a/src/rdynload.c
+++ b/src/rdynload.c
@@ -9,7 +9,21 @@
 #include "dynload.h"
 #include <string.h>
 
+#define RDYNCALL_LIBHANDLE_TAG "rdyncall.libhandle"
+
 SEXP C_dynpath(SEXP libh);
+
+static SEXP C_libhandle_tag(void)
+{
+  return Rf_install(RDYNCALL_LIBHANDLE_TAG);
+}
+
+static int C_is_libhandle(SEXP libh)
+{
+  return TYPEOF(libh) == EXTPTRSXP &&
+    R_ExternalPtrAddr(libh) != NULL &&
+    R_ExternalPtrTag(libh) == C_libhandle_tag();
+}
 
 #if defined(__APPLE__)
 #define RDYNCALL_DARWIN_LIBSYSTEM_PATH "/usr/lib/libSystem.B.dylib"
@@ -140,7 +154,12 @@ SEXP C_dynload(SEXP libpath_x)
   if (!libHandle)
     return R_NilValue;
 
-  return R_MakeExternalPtr(libHandle, R_NilValue, R_NilValue);
+  return R_MakeExternalPtr(libHandle, C_libhandle_tag(), R_NilValue);
+}
+
+SEXP C_is_dynload_handle(SEXP libh)
+{
+  return Rf_ScalarLogical(C_is_libhandle(libh));
 }
 
 /** ---------------------------------------------------------------------------

--- a/src/rpackage.c
+++ b/src/rpackage.c
@@ -23,6 +23,7 @@ SEXP C_dynlist(SEXP libh);
 SEXP C_dynload(SEXP libpath);
 SEXP C_dynsym(SEXP libobj, SEXP symname, SEXP protectlib);
 SEXP C_dynunload(SEXP libobj);
+SEXP C_is_dynload_handle(SEXP libobj);
 
 /* rpack.c */
 SEXP C_pack(SEXP ptr, SEXP offset, SEXP sig, SEXP value);
@@ -76,6 +77,7 @@ R_CallMethodDef callMethods[] =
   {"C_dynload"                  , (DL_FUNC) &C_dynload          , 1},
   {"C_dynsym"                   , (DL_FUNC) &C_dynsym           , 3},
   {"C_dynunload"                , (DL_FUNC) &C_dynunload        , 1},
+  {"C_is_dynload_handle"        , (DL_FUNC) &C_is_dynload_handle, 1},
   {"C_dynpath"                  , (DL_FUNC) &C_dynpath          , 1},
   {"C_dyncount"                 , (DL_FUNC) &C_dyncount         , 1},
   {"C_dynlist"                  , (DL_FUNC) &C_dynlist          , 1},


### PR DESCRIPTION
## Summary

Adds direct `dynbind()` support for character library paths and existing rdyncall library handles, while preserving short-name `dynfind()` behavior.

## Changes

- Resolves character `libnames` candidate-by-candidate: paths go through `dynload()`, short names go through `dynfind()`.
- Tags `dynload()` library handles internally and rejects unrelated external pointers in `dynbind()`.
- Adds tinytest coverage for short names, absolute and relative paths, valid handles, and invalid external pointers.

## Out of scope

- Broader validation changes for direct `dynsym()`/`dynpath()` callers.