### PR TITLE
feat: improve dynfind package manager discovery

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 - Generate real on-disk R packages from DCF DynPort files via `dynport()`.
 - Allow `dynbind()` to accept direct library paths and existing external
   pointer handles in addition to short library names.
+- Improve `dynfind()` discovery for libraries installed by common package
+  managers, including Homebrew, MacPorts, Linuxbrew and Scoop.
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.
 - Store aggregate field names in the explicit `typeinfo$fields$name` column.
 - Add `struct` and `union` bitfield layout, access, DynPort parsing, and by-value aggregate support.

--- a/R/dynfind.R
+++ b/R/dynfind.R
@@ -1,19 +1,110 @@
-dynfind1 <- if (.Platform$OS.type == "windows") {
-    function(name, ...) {
-        handle <- dynload(paste("lib", name, sep = ""), ...)
+dynfind_values <- function(x) {
+    unique(x[!is.na(x) & nzchar(x)])
+}
+
+dynfind_name_variants <- function(name) {
+    dynfind_values(c(name, tolower(name), toupper(name)))
+}
+
+dynfind_try <- function(paths, ..., existing.only = FALSE) {
+    paths <- dynfind_values(paths)
+    if (existing.only) {
+        paths <- paths[file.exists(paths)]
+    }
+    for (path in paths) {
+        handle <- dynload(path, ...)
         if (!is.null(handle)) {
             return(handle)
         }
-        dynload(name, ...)
+    }
+    NULL
+}
+
+dynfind_files <- function(dirs, patterns) {
+    dirs <- dynfind_values(dirs)
+    dirs <- dirs[dir.exists(dirs)]
+    if (!length(dirs)) {
+        return(character())
+    }
+    unique(unlist(lapply(dirs, function(dir) {
+        unlist(lapply(patterns, function(pattern) {
+            Sys.glob(file.path(dir, pattern))
+        }), use.names = FALSE)
+    }), use.names = FALSE))
+}
+
+dynfind_package_manager_dirs <- function(name) {
+    names <- dynfind_name_variants(name)
+    if (.Platform$OS.type == "windows") {
+        userprofile <- Sys.getenv("USERPROFILE", "")
+        programdata <- Sys.getenv("ProgramData", "")
+        roots <- dynfind_values(c(
+            Sys.getenv("SCOOP", ""),
+            Sys.getenv("SCOOP_GLOBAL", ""),
+            if (nzchar(userprofile)) file.path(userprofile, "scoop") else character(),
+            if (nzchar(programdata)) file.path(programdata, "scoop") else character()
+        ))
+        return(unique(unlist(lapply(roots, function(root) {
+            c(
+                file.path(root, "apps", names, "current", "bin"),
+                file.path(root, "apps", names, "current", "lib"),
+                file.path(root, "apps", names, "current")
+            )
+        }), use.names = FALSE)))
+    }
+
+    if (Sys.info()[["sysname"]] == "Darwin") {
+        homebrew <- dynfind_values(c(Sys.getenv("HOMEBREW_PREFIX", ""), "/opt/homebrew", "/usr/local"))
+        macports <- dynfind_values(c(Sys.getenv("MACPORTS_PREFIX", ""), "/opt/local"))
+        return(unique(c(
+            file.path(homebrew, "lib"),
+            unlist(lapply(homebrew, function(root) {
+                file.path(root, "opt", names, "lib")
+            }), use.names = FALSE),
+            file.path(macports, "lib")
+        )))
+    }
+
+    homebrew <- dynfind_values(c(Sys.getenv("HOMEBREW_PREFIX", ""), "/home/linuxbrew/.linuxbrew"))
+    unique(c(
+        file.path(homebrew, "lib"),
+        unlist(lapply(homebrew, function(root) {
+            file.path(root, "opt", names, "lib")
+        }), use.names = FALSE)
+    ))
+}
+
+dynfind_package_manager_files <- function(name) {
+    names <- dynfind_name_variants(name)
+    patterns <- if (.Platform$OS.type == "windows") {
+        c(paste0(names, ".dll"), paste0("lib", names, ".dll"), paste0(names, "*.dll"), paste0("lib", names, "*.dll"))
+    } else if (Sys.info()[["sysname"]] == "Darwin") {
+        c(paste0("lib", names, ".dylib"), paste0("lib", names, ".*.dylib"))
+    } else {
+        c(paste0("lib", names, ".so"), paste0("lib", names, ".so.*"))
+    }
+    dynfind_files(dynfind_package_manager_dirs(name), patterns)
+}
+
+dynfind1 <- if (.Platform$OS.type == "windows") {
+    function(name, ...) {
+        handle <- dynfind_try(c(paste("lib", name, sep = ""), name), ...)
+        if (!is.null(handle)) {
+            return(handle)
+        }
+        dynfind_try(dynfind_package_manager_files(name), ..., existing.only = TRUE)
     }
 } else {
     if (Sys.info()[["sysname"]] == "Darwin") {
         function(name, ...) {
-            handle <- dynload(paste(name, ".framework/", name, sep = ""), ...)
+            handle <- dynfind_try(c(
+                paste(name, ".framework/", name, sep = ""),
+                paste("lib", name, ".dylib", sep = "")
+            ), ...)
             if (!is.null(handle)) {
                 return(handle)
             }
-            handle <- dynload(paste("lib", name, ".dylib", sep = ""), ...)
+            handle <- dynfind_try(dynfind_package_manager_files(name), ..., existing.only = TRUE)
             if (!is.null(handle)) {
                 return(handle)
             }
@@ -30,23 +121,26 @@ dynfind1 <- if (.Platform$OS.type == "windows") {
             #
             # Also, for C libraries, it seems that using
             # '/usr/lib/system/libsystem_*' works for 'dlSymsName'
-            handle <- dynload(paste("/usr/lib/system/libsystem_", name, ".dylib", sep = ""), ...)
+            handle <- dynfind_try(paste("/usr/lib/system/libsystem_", name, ".dylib", sep = ""), ...)
             if (!is.null(handle)) {
                 return(handle)
             }
-            dynload(paste("/usr/lib/lib", name, ".dylib", sep = ""), ...)
+            dynfind_try(paste("/usr/lib/lib", name, ".dylib", sep = ""), ...)
         }
     } else {
         function(name, ...) {
-            handle <- dynload(paste("lib", name, ".so", sep = ""), ...)
+            handle <- dynfind_try(c(
+                paste("lib", name, ".so", sep = ""),
+                paste("lib", name, sep = "")
+            ), ...)
             if (!is.null(handle)) {
                 return(handle)
             }
-            handle <- dynload(paste("lib", name, sep = ""), ...)
+            handle <- dynfind_try(dynfind_package_manager_files(name), ..., existing.only = TRUE)
             if (!is.null(handle)) {
                 return(handle)
             }
-            dynload(paste(name, sep = ""), ...) # needed by Solaris to lookup 'R'.
+            dynfind_try(paste(name, sep = ""), ...) # needed by Solaris to lookup 'R'.
         }
     }
 }
@@ -103,10 +197,13 @@ dynfind1 <- if (.Platform$OS.type == "windows") {
 #' useful for all platforms}
 #' }
 #'
-#' The vector of `location`s is initialized by environment variables such
-#' as `PATH` on Windows and `LD_LIBRARY_PATH` on Unix-flavour systems in
-#' additional to some hardcoded locations: `/opt/local/lib`, `/usr/local/lib`,
-#' `/usr/lib` and `/lib`.
+#' The vector of `location`s is initialized by the dynamic linker search rules,
+#' including environment variables such as `PATH` on Windows and
+#' `LD_LIBRARY_PATH` on Unix-flavour systems. If the dynamic linker lookup
+#' fails, `dynfind()` also checks common package-manager library locations such
+#' as Homebrew (`HOMEBREW_PREFIX`, `/opt/homebrew`, `/usr/local`), MacPorts
+#' (`MACPORTS_PREFIX`, `/opt/local`), Linuxbrew (`/home/linuxbrew/.linuxbrew`)
+#' and Scoop (`SCOOP`, `SCOOP_GLOBAL`, `ProgramData/scoop`).
 #' (The set of hardcoded locations might expand and change within the next minor releases).
 #'
 #' The file extension depends on the OS: `.dll` (Windows), `.dylib` (macOS),

--- a/inst/tinytest/test_dynfind.R
+++ b/inst/tinytest/test_dynfind.R
@@ -1,1 +1,62 @@
 expect_true(is.externalptr(dynfind(c("msvcrt", "m", "m.so.6"))))
+
+build_dynfind_fixture <- function() {
+    src <- system.file("tinytest", "dynbind.c", package = "rdyncall", mustWork = TRUE)
+    outdir <- tempfile("rdyncall-dynfind-fixture-")
+    dir.create(outdir)
+    target <- file.path(outdir, "rdyncall_dynfind_fixture.c")
+    file.copy(src, target)
+
+    oldwd <- setwd(outdir)
+    on.exit(setwd(oldwd), add = TRUE)
+    out <- system2(
+        file.path(R.home("bin"), "R"),
+        c("CMD", "SHLIB", basename(target)),
+        stdout = TRUE, stderr = TRUE
+    )
+    if (!is.null(attr(out, "status")) && attr(out, "status") != 0) {
+        stop(paste(c("failed to build dynfind test fixture", out), collapse = "\n"), call. = FALSE)
+    }
+
+    lib <- file.path(outdir, paste0("rdyncall_dynfind_fixture", .Platform$dynlib.ext))
+    if (!file.exists(lib)) {
+        stop("failed to build dynfind test fixture", call. = FALSE)
+    }
+    lib
+}
+
+with_dynfind_env <- function(name, value, expr) {
+    old <- Sys.getenv(name, unset = NA_character_)
+    on.exit({
+        if (is.na(old)) {
+            Sys.unsetenv(name)
+        } else {
+            do.call(Sys.setenv, as.list(stats::setNames(old, name)))
+        }
+    }, add = TRUE)
+    do.call(Sys.setenv, as.list(stats::setNames(value, name)))
+    force(expr)
+}
+
+fixture <- build_dynfind_fixture()
+libname <- "rdyncallfixture"
+prefix <- tempfile("rdyncall-dynfind-prefix-")
+
+if (.Platform$OS.type == "windows") {
+    libdir <- file.path(prefix, "apps", libname, "current", "bin")
+    dir.create(libdir, recursive = TRUE)
+    file.copy(fixture, file.path(libdir, paste0(libname, ".dll")))
+
+    with_dynfind_env("SCOOP", prefix, {
+        expect_true(is.externalptr(dynfind(libname)))
+    })
+} else {
+    libdir <- file.path(prefix, "lib")
+    dir.create(libdir, recursive = TRUE)
+    suffix <- if (Sys.info()[["sysname"]] == "Darwin") ".dylib" else ".so"
+    file.copy(fixture, file.path(libdir, paste0("lib", libname, suffix)))
+
+    with_dynfind_env("HOMEBREW_PREFIX", prefix, {
+        expect_true(is.externalptr(dynfind(libname)))
+    })
+}

--- a/man/dynfind.Rd
+++ b/man/dynfind.Rd
@@ -66,10 +66,13 @@ Here is a sample list of values for the three other components:
 useful for all platforms}
 }
 
-The vector of \code{location}s is initialized by environment variables such
-as \code{PATH} on Windows and \code{LD_LIBRARY_PATH} on Unix-flavour systems in
-additional to some hardcoded locations: \verb{/opt/local/lib}, \verb{/usr/local/lib},
-\verb{/usr/lib} and \verb{/lib}.
+The vector of \code{location}s is initialized by the dynamic linker search rules,
+including environment variables such as \code{PATH} on Windows and
+\code{LD_LIBRARY_PATH} on Unix-flavour systems. If the dynamic linker lookup
+fails, \code{dynfind()} also checks common package-manager library locations such
+as Homebrew (\code{HOMEBREW_PREFIX}, \verb{/opt/homebrew}, \verb{/usr/local}), MacPorts
+(\code{MACPORTS_PREFIX}, \verb{/opt/local}), Linuxbrew (\verb{/home/linuxbrew/.linuxbrew})
+and Scoop (\code{SCOOP}, \code{SCOOP_GLOBAL}, \code{ProgramData/scoop}).
 (The set of hardcoded locations might expand and change within the next minor releases).
 
 The file extension depends on the OS: \code{.dll} (Windows), \code{.dylib} (macOS),


### PR DESCRIPTION
## Summary

- Improve dynfind() so short library names can resolve libraries installed in common package-manager prefixes.
- Cover Homebrew, MacPorts, Linuxbrew, and Scoop without changing the public API.

## Changes

- Keep the existing dynamic linker lookup first, then search package-manager library directories as a fallback.
- Add tinytest coverage using a temporary shared library in Homebrew/Scoop-style layouts.
- Update NEWS and dynfind documentation.

## Out of scope

- Demo updates; the demo PR can remove its local SDL3 discovery fallback after this lands.