### PR TITLE
fix: materialize nested aggregate fields as structs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
   pointer handles in addition to short library names.
 - Improve `dynfind()` discovery for libraries installed by common package
   managers, including Homebrew, MacPorts, Linuxbrew and Scoop.
+- Return nested aggregate fields from `$` as raw-backed `struct` objects so
+  they can be reused for field access and aggregate by-value calls.
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.
 - Store aggregate field names in the explicit `typeinfo$fields$name` column.
 - Add `struct` and `union` bitfield layout, access, DynPort parsing, and by-value aggregate support.

--- a/R/struct.R
+++ b/R/struct.R
@@ -817,6 +817,19 @@ cdata <- function(type) {
     return(x)
 }
 
+as_aggregate_field <- function(x, type) {
+    if (is.character(type)) {
+        type <- get_typeinfo(type)
+    } else if (!is.typeinfo(type)) {
+        stop("type is not of class typeinfo and no character string")
+    }
+    if (!type$type %in% c("struct", "union")) stop("type must be C struct or union.")
+    class(x) <- "struct"
+    attr(x, "struct") <- type$name
+    attr(x, "typeinfo") <- type
+    x
+}
+
 struct_typeinfo <- function(x, envir = parent.frame()) {
     struct_name <- attr(x, "struct")
     info <- attr(x, "typeinfo")
@@ -874,9 +887,9 @@ unpack_aggregate_array_field <- function(x, offset, field_type_name, field_type_
         element_offset <- offset + (i - 1L) * field_type_info$size
         if (is.raw(x)) {
             size <- field_type_info$size
-            as.ctype(x[(element_offset + 1):(element_offset + size)], field_type_name)
+            as_aggregate_field(x[(element_offset + 1):(element_offset + size)], field_type_info)
         } else if (is.externalptr(x)) {
-            as.ctype(offset_ptr(x, element_offset), field_type_name)
+            as_aggregate_field(offset_ptr(x, element_offset), field_type_info)
         }
     }
 
@@ -905,7 +918,8 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
 #' @rdname struct
 #' @export
 `$.struct` <- unpack.struct <- function(x, index) {
-    struct_info <- struct_typeinfo(x, parent.frame())
+    caller <- parent.frame()
+    struct_info <- struct_typeinfo(x, caller)
     field_info <- struct_info$fields
     field_index <- match(index, field_info$name)
     if (is.na(field_index)) stop("unknown field index '", index, "'")
@@ -919,7 +933,7 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
     }
     offset <- field_info[field_index, "offset"]
     field_type_name <- as.character(field_info[[field_index, "type"]])
-    field_type_info <- get_typeinfo(field_type_name)
+    field_type_info <- get_typeinfo(field_type_name, caller)
     array_len <- field_array_len(field_info, field_index)
     if (field_type_info$type %in% c("base", "pointer")) {
         unpack_array_field(x, offset, field_type_info, array_len)
@@ -933,7 +947,8 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
 #' @rdname struct
 #' @export
 `$<-.struct` <- pack.struct <- function(x, index, value) {
-    struct_info <- struct_typeinfo(x, parent.frame())
+    caller <- parent.frame()
+    struct_info <- struct_typeinfo(x, caller)
     field_info <- struct_info$fields
     field_index <- match(index, field_info$name)
     if (is.na(field_index)) stop("unknown field index '", index, "'")
@@ -948,7 +963,7 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
     }
     offset <- field_info[field_index, "offset"]
     field_type_name <- as.character(field_info[field_index, "type"])
-    field_type_info <- get_typeinfo(field_type_name)
+    field_type_info <- get_typeinfo(field_type_name, caller)
     array_len <- field_array_len(field_info, field_index)
     if (field_type_info$type %in% c("base", "pointer")) {
         pack_array_field(x, offset, field_type_info, array_len, value)

--- a/inst/tinytest/test_dyncall.R
+++ b/inst/tinytest/test_dyncall.R
@@ -187,12 +187,18 @@ pack(nested_vec2, nested_base + field_offset(Vec2, "x"), "f", 5.5)
 pack(nested_vec2, nested_base + field_offset(Vec2, "y"), "f", 6.25)
 nested_sum <- dynsym(aggregate_fixture, "rdyncall_test_nested_vec2_sum")
 expect_equal(dyncall(nested_sum, "<NestedVec2>)d", nested_vec2), 11.75)
+nested_xy <- nested_vec2$xy
+expect_struct_raw(nested_xy, "Vec2")
+expect_equal(dyncall(vec2_sum, "<Vec2>)d", nested_xy), 11.75)
 
 make_nested_vec2 <- dynsym(aggregate_fixture, "rdyncall_test_make_nested_vec2")
 nested_ret <- dyncall(make_nested_vec2, "ff)<NestedVec2>", 7.5, 8.25)
 expect_struct_raw(nested_ret, "NestedVec2")
 expect_equal(unpack(nested_ret, nested_base + field_offset(Vec2, "x"), "f"), 7.5)
 expect_equal(unpack(nested_ret, nested_base + field_offset(Vec2, "y"), "f"), 8.25)
+nested_ret_xy <- nested_ret$xy
+expect_struct_raw(nested_ret_xy, "Vec2")
+expect_equal(dyncall(vec2_sum, "<Vec2>)d", nested_ret_xy), 15.75)
 
 # Three-double HFA aggregate return stays in FP return registers even though size is over 16 bytes.
 cstruct("ThreeDouble{ddd}a b c;")

--- a/inst/tinytest/test_dynstruct.R
+++ b/inst/tinytest/test_dynstruct.R
@@ -212,6 +212,43 @@ expect_equal(fixed_array_access$bytes, 1:4)
 expect_equal(fixed_array_access$tag, 42L)
 expect_error(fixed_array_access$bytes <- 1:3, "fixed array field length")
 
+local({
+    cstruct("NestedFieldVec2{ff}x y;")
+    cstruct("NestedFieldHolder{<NestedFieldVec2>}xy;")
+    cstruct("NestedFieldArrayHolder{<NestedFieldVec2>[2]}xy;")
+
+    holder <- cdata(NestedFieldHolder)
+    holder_base <- NestedFieldHolder$fields$offset[match("xy", NestedFieldHolder$fields$name)]
+    pack(holder, holder_base + NestedFieldVec2$fields$offset[match("x", NestedFieldVec2$fields$name)], "f", 1.25)
+    pack(holder, holder_base + NestedFieldVec2$fields$offset[match("y", NestedFieldVec2$fields$name)], "f", 2.5)
+
+    xy <- holder$xy
+    expect_true(is.raw(xy))
+    expect_true(inherits(xy, "struct"))
+    expect_equal(attr(xy, "struct"), "NestedFieldVec2")
+    expect_equal(attr(xy, "typeinfo"), NestedFieldVec2)
+    expect_equal(xy$x, 1.25)
+    expect_equal(xy$y, 2.5)
+
+    array_holder <- cdata(NestedFieldArrayHolder)
+    array_base <- NestedFieldArrayHolder$fields$offset[match("xy", NestedFieldArrayHolder$fields$name)]
+    pack(array_holder, array_base + NestedFieldVec2$fields$offset[match("x", NestedFieldVec2$fields$name)], "f", 1.25)
+    pack(array_holder, array_base + NestedFieldVec2$fields$offset[match("y", NestedFieldVec2$fields$name)], "f", 2.5)
+    pack(array_holder, array_base + NestedFieldVec2$size + NestedFieldVec2$fields$offset[match("x", NestedFieldVec2$fields$name)], "f", 3.5)
+    pack(array_holder, array_base + NestedFieldVec2$size + NestedFieldVec2$fields$offset[match("y", NestedFieldVec2$fields$name)], "f", 4.75)
+
+    xy_array <- array_holder$xy
+    expect_true(is.list(xy_array))
+    expect_equal(length(xy_array), 2L)
+    expect_true(all(vapply(xy_array, inherits, logical(1L), "struct")))
+    expect_equal(vapply(xy_array, attr, character(1L), "struct"), rep("NestedFieldVec2", 2L))
+    expect_equal(lapply(xy_array, attr, "typeinfo"), list(NestedFieldVec2, NestedFieldVec2))
+    expect_equal(xy_array[[1L]]$x, 1.25)
+    expect_equal(xy_array[[1L]]$y, 2.5)
+    expect_equal(xy_array[[2L]]$x, 3.5)
+    expect_equal(xy_array[[2L]]$y, 4.75)
+})
+
 expect_null(cstruct("PackedCharDouble{Cd} c d @packed;", env))
 expect_equal(env$PackedCharDouble$size, 9L)
 expect_equal(env$PackedCharDouble$align, 1L)


### PR DESCRIPTION
## Summary

Closes #32.

Fix nested aggregate field access so `$` returns raw-backed `struct` objects instead of legacy `ctype` wrappers. This lets fields from nested structs/unions be reused for further `$` access, `pack()`/`unpack()`, and aggregate by-value `dyncall()` calls.

## Changes

- Materialize nested aggregate fields with `class = "struct"`, `attr("struct")`, and registered `typeinfo` metadata.
- Preserve the existing exported `as.ctype()` behavior outside this accessor path.
- Add tinytest coverage for nested aggregate fields, nested aggregate arrays, and by-value calls using fields returned from `$`.
- Update `NEWS.md`.

## Out of scope

This does not change nested assignment semantics such as `nested$xy$x <- value`; `$xy` remains a raw slice/copy.