### PR TITLE
fix: build embedded dyncall x64 as PIC

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -7,5 +7,5 @@ all: $(SHLIB)
 $(SHLIB): mylibs
 
 mylibs:
-	(cd dyncall ; CC="$(CC)" AR="$(AR)" CFLAGS="-fPIC $(CFLAGS)" CPPFLAGS="-DNDEBUG ${CPPFLAGS}" make -f Makefile.embedded)
+	(cd dyncall ; CC="$(CC)" AR="$(AR)" CFLAGS="-fPIC $(CFLAGS)" ASFLAGS="-fPIC $(ASFLAGS)" CPPFLAGS="-DNDEBUG ${CPPFLAGS}" make -f Makefile.embedded)
 

--- a/src/dyncall/dyncall/dyncall_call_x64.S
+++ b/src/dyncall/dyncall/dyncall_call_x64.S
@@ -45,6 +45,9 @@ BEGIN_ASM
 
 GLOBAL(dcCall_x64_sysv)
 BEGIN_PROC(dcCall_x64_sysv)
+#if !defined(GEN_MASM)
+LOCAL(dcCall_x64_sysv):
+#endif
 	PUSH(RBP)			/* Pseudo-prolog - preserve RBP. */
 	PUSH(RBX)			/* Preserve RBX and store pointer to function in it. */
 	MOV(RSP,RBP)			/* Store stack pointer in RBP. */
@@ -88,7 +91,7 @@ END_PROC(dcCall_x64_sysv)
 GLOBAL(dcCall_x64_sysv_aggr)
 BEGIN_PROC(dcCall_x64_sysv_aggr)
 	PUSH(R9)			/* preserve ptr to copy retval regs to (also realigns stack) */
-	CALL(CSYM(dcCall_x64_sysv))	/* params (in regs) passed-through to next call, as-is */
+	CALL(LOCAL(dcCall_x64_sysv))	/* params (in regs) passed-through to next call, as-is */
 	POP(R9)				/* get ptr to retval regs back */
 
 	/* copy regs holding aggregate data to provided space (pointed to by r12) */
@@ -114,6 +117,9 @@ END_PROC(dcCall_x64_sysv_aggr)
 
 GLOBAL_FRAME(dcCall_x64_win64)
 FRAME_BEGIN_PROC(dcCall_x64_win64)
+#if !defined(GEN_MASM)
+LOCAL(dcCall_x64_win64):
+#endif
 
 	PUSH(RBP)			/* Pseudo-prolog - preserve RBP. */
 	FRAME_PUSH_REG(RBP)
@@ -167,7 +173,7 @@ END_PROC(dcCall_x64_win64)
 GLOBAL(dcCall_x64_win64_aggr)
 BEGIN_PROC(dcCall_x64_win64_aggr)
 	SUB(LIT(8), RSP)		/* Re-align the stack */
-	CALL(CSYM(dcCall_x64_win64))	/* params (in regs) passed-through to next call, as-is */
+	CALL(LOCAL(dcCall_x64_win64))	/* params (in regs) passed-through to next call, as-is */
 	ADD(LIT(8), RSP)		/* Restore the stack pointer */
 
 	MOV(QWORD(RSP, 40), R8)		/* ptr to aggregate mem -> R8 (passed as only stack arg, 0x40 to skip ret addr and spill area */

--- a/tools/patches/dyncall-x64-pic-local-labels.patch
+++ b/tools/patches/dyncall-x64-pic-local-labels.patch
@@ -1,0 +1,18 @@
+diff --git a/src/dyncall/dyncall/dyncall_call_x64.S b/src/dyncall/dyncall/dyncall_call_x64.S
+index 12addf9..a066a7b 100644
+--- a/src/dyncall/dyncall/dyncall_call_x64.S
++++ b/src/dyncall/dyncall/dyncall_call_x64.S
+@@ -47,0 +48,3 @@ BEGIN_PROC(dcCall_x64_sysv)
++#if !defined(GEN_MASM)
++LOCAL(dcCall_x64_sysv):
++#endif
+@@ -91 +94 @@ BEGIN_PROC(dcCall_x64_sysv_aggr)
+-	CALL(CSYM(dcCall_x64_sysv))	/* params (in regs) passed-through to next call, as-is */
++	CALL(LOCAL(dcCall_x64_sysv))	/* params (in regs) passed-through to next call, as-is */
+@@ -116,0 +120,3 @@ FRAME_BEGIN_PROC(dcCall_x64_win64)
++#if !defined(GEN_MASM)
++LOCAL(dcCall_x64_win64):
++#endif
+@@ -170 +176 @@ BEGIN_PROC(dcCall_x64_win64_aggr)
+-	CALL(CSYM(dcCall_x64_win64))	/* params (in regs) passed-through to next call, as-is */
++	CALL(LOCAL(dcCall_x64_win64))	/* params (in regs) passed-through to next call, as-is */


### PR DESCRIPTION
## Summary

Fix the embedded dyncall x64 build for older Linux linkers by making the aggregate wrapper calls target local assembler labels and by passing PIC flags to assembler sources.

## Changes

- Pass `ASFLAGS="-fPIC $(ASFLAGS)"` into the embedded dyncall build.
- Add GNU assembler local labels for `dcCall_x64_sysv` and `dcCall_x64_win64`, then route the aggregate wrappers through those local labels.
- Add `tools/patches/dyncall-x64-pic-local-labels.patch` so the vendored dyncall fix survives future bootstrap updates.

## Out of scope

- No R API or dynport behavior changes.
- No linker-wide `-Bsymbolic` or symbol visibility changes.
