### PR TITLE
feat: add variadic dyncall support

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@ useDynLib(rdyncall)
 export(
 # --- dyncall.R --------------------------------------------------------------
   dyncall,
+  dyncall_variadic,
   dyncall.default,
   dyncall.cdecl,
   dyncall.stdcall,

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - Replace deprecated/internal R C API usage with public accessors where possible.
 - Support `dynlist()` for macOS dyld shared cache libraries.
 - Generate real on-disk R packages from DCF DynPort files via `dynport()`.
+- Add `dyncall_variadic()` for calling C variadic functions with explicit
+  call-site vararg signatures.
 - Allow `dynbind()` to accept direct library paths and existing external
   pointer handles in addition to short library names.
 - Improve `dynfind()` discovery for libraries installed by common package

--- a/R/dyncall.R
+++ b/R/dyncall.R
@@ -39,6 +39,7 @@ callvm.thiscall.msvc <- NULL
 callvm.fastcall      <- NULL
 callvm.fastcall.gcc  <- NULL
 callvm.fastcall.msvc <- NULL
+callvm.variadic      <- NULL
 
 # ----------------------------------------------------------------------------
 # aggregate by-value support (internal)
@@ -186,6 +187,11 @@ dyncall_aggregate_layouts <- function(signature, envir = parent.frame()) {
         i <- i + 1L
 
         if (ch == ")") break
+        if (ch == "_") {
+            i <- i + 1L
+            ptrcnt <- 0L
+            next
+        }
         if (ch == "*") {
             ptrcnt <- ptrcnt + 1L
             next
@@ -228,6 +234,30 @@ dyncall_call <- function(callvm, address, signature, ..., envir = parent.frame()
         attr(ans, "typeinfo") <- get_typeinfo(aggregates$return$name, envir = envir)
     }
     ans
+}
+
+dyncall_variadic_signature <- function(signature, varargs) {
+    if (!is.character(signature) || length(signature) != 1L || is.na(signature) || !nzchar(signature)) {
+        stop("'signature' must be a single non-empty character string.", call. = FALSE)
+    }
+    if (!is.character(varargs) || length(varargs) != 1L || is.na(varargs)) {
+        stop("'varargs' must be a single character string.", call. = FALSE)
+    }
+    if (startsWith(signature, "_")) {
+        stop("variadic signatures must not include a calling-convention prefix.", call. = FALSE)
+    }
+    if (grepl(")", varargs, fixed = TRUE)) {
+        stop("'varargs' must contain only argument type signatures, not a return signature.", call. = FALSE)
+    }
+
+    end <- regexpr(")", signature, fixed = TRUE)[[1L]]
+    if (end < 1L || end == nchar(signature)) {
+        stop("'signature' must be a complete call signature with a return type.", call. = FALSE)
+    }
+
+    args <- substr(signature, 1L, end - 1L)
+    ret <- substr(signature, end + 1L, nchar(signature))
+    paste0("_e", args, "_.", varargs, ")", ret)
 }
 
 # ----------------------------------------------------------------------------
@@ -278,6 +308,12 @@ dyncall_call <- function(callvm, address, signature, ..., envir = parent.frame()
 #'
 #' Arguments passed via `...` are converted to C according to `signature`; see
 #' below for details.
+#'
+#' `dyncall_variadic()` calls C functions declared with `...`. The `signature`
+#' argument describes the fixed parameter prefix and return type, while
+#' `varargs` describes the actual argument types passed through `...` at this
+#' specific call site. C default promotions are the caller's responsibility; for
+#' example, pass promoted variadic `float` values as `double` (`"d"`).
 #'
 #' Given that the `signature` matches the foreign function type, the FFI
 #' provides a certain level of type-safety to users, when exposing foreign
@@ -438,6 +474,11 @@ dyncall_call <- function(callvm, address, signature, ..., envir = parent.frame()
 #'        converted from R to C values according to the _call signature_. See
 #'        details.
 #'
+#' @param varargs character string specifying the type signatures for the
+#'        arguments passed through the C `...` portion of a variadic function.
+#'        This string contains argument types only, without `)` and without a
+#'        return type.
+#'
 #' @param callmode character string specifying the _calling convention_. This
 #'        argument has no effect on most platforms, but on Microsoft Windows
 #'        32-Bit Intel/x86 platforms. See details.
@@ -483,6 +524,13 @@ dyncall <- function(address, signature, ..., callmode = "default") {
         fastcall.msvc = callvm.fastcall.msvc
     )
     dyncall_call(callvm, address, signature, ..., envir = parent.frame())
+}
+
+#' @rdname dyncall
+#' @export
+dyncall_variadic <- function(address, signature, varargs = "", ..., callmode = c("default", "cdecl")) {
+    callmode <- match.arg(callmode)
+    dyncall_call(callvm.variadic, address, dyncall_variadic_signature(signature, varargs), ..., envir = parent.frame())
 }
 
 #' @rdname dyncall
@@ -535,4 +583,5 @@ dyncall.fastcall      <- dyncall.fastcall.gcc
     callvm.fastcall      <<- callvm_new("fastcall", size)
     callvm.fastcall.gcc  <<- callvm_new("fastcall.gcc", size)
     callvm.fastcall.msvc <<- callvm_new("fastcall.msvc", size)
+    callvm.variadic      <<- callvm_new("cdecl", size)
 }

--- a/inst/tinytest/dynbind.c
+++ b/inst/tinytest/dynbind.c
@@ -1,4 +1,32 @@
+#include <stdarg.h>
+
 int rdyncall_dynbind_add(int x, int y)
 {
+    return x + y;
+}
+
+int rdyncall_dynbind_sum_variadic(int x, ...)
+{
+    va_list args;
+    int y;
+    int z;
+
+    va_start(args, x);
+    y = va_arg(args, int);
+    z = va_arg(args, int);
+    va_end(args);
+
+    return x + y + z;
+}
+
+double rdyncall_dynbind_sum_variadic_double(double x, ...)
+{
+    va_list args;
+    double y;
+
+    va_start(args, x);
+    y = va_arg(args, double);
+    va_end(args);
+
     return x + y;
 }

--- a/inst/tinytest/test_dynbind.R
+++ b/inst/tinytest/test_dynbind.R
@@ -42,13 +42,23 @@ fixture <- build_dynbind_fixture()
 
 expect_dynbind_add(fixture)
 
+handle <- dynload(fixture)
+sum_variadic <- dynsym(handle, "rdyncall_dynbind_sum_variadic")
+expect_equal(dyncall_variadic(sum_variadic, "i)i", "ii", 1L, 2L, 3L), 6L)
+
+sum_variadic_double <- dynsym(handle, "rdyncall_dynbind_sum_variadic_double")
+expect_equal(dyncall_variadic(sum_variadic_double, "d)d", "d", 1.5, 2.25), 3.75)
+expect_error(
+    dyncall_variadic(sum_variadic, "i)i", "i)i", 1L, 2L),
+    "argument type signatures"
+)
+
 local({
     oldwd <- setwd(dirname(fixture))
     on.exit(setwd(oldwd), add = TRUE)
     expect_dynbind_add(file.path(".", basename(fixture)))
 })
 
-handle <- dynload(fixture)
 attr(handle, "dynbind-test") <- "input-handle"
 bind <- expect_dynbind_add(handle)
 expect_equal(attr(bind$libhandle, "dynbind-test"), "input-handle")

--- a/man/dyncall.Rd
+++ b/man/dyncall.Rd
@@ -4,6 +4,7 @@
 \alias{dyncall}
 \alias{call-signature}
 \alias{type-signature}
+\alias{dyncall_variadic}
 \alias{dyncall.cdecl}
 \alias{dyncall.default}
 \alias{dyncall.stdcall}
@@ -16,6 +17,14 @@
 \title{Foreign Function Interface with support for almost all C types}
 \usage{
 dyncall(address, signature, ..., callmode = "default")
+
+dyncall_variadic(
+  address,
+  signature,
+  varargs = "",
+  ...,
+  callmode = c("default", "cdecl")
+)
 
 dyncall.cdecl(address, signature, ...)
 
@@ -48,6 +57,11 @@ details.}
 \item{callmode}{character string specifying the \emph{calling convention}. This
 argument has no effect on most platforms, but on Microsoft Windows
 32-Bit Intel/x86 platforms. See details.}
+
+\item{varargs}{character string specifying the type signatures for the
+arguments passed through the C \code{...} portion of a variadic function.
+This string contains argument types only, without \verb{)} and without a
+return type.}
 }
 \value{
 Functions return the received C return value converted to an R value. See
@@ -96,6 +110,12 @@ resize already-created CallVM objects.
 
 Arguments passed via \code{...} are converted to C according to \code{signature}; see
 below for details.
+
+\code{dyncall_variadic()} calls C functions declared with \code{...}. The \code{signature}
+argument describes the fixed parameter prefix and return type, while
+\code{varargs} describes the actual argument types passed through \code{...} at this
+specific call site. C default promotions are the caller's responsibility; for
+example, pass promoted variadic \code{float} values as \code{double} (\code{"d"}).
 
 Given that the \code{signature} matches the foreign function type, the FFI
 provides a certain level of type-safety to users, when exposing foreign

--- a/src/rdyncall.c
+++ b/src/rdyncall.c
@@ -250,6 +250,28 @@ static void rdyncall_set_struct_attrib(SEXP x, const char *name)
   Rf_setAttrib(x, R_ClassSymbol, Rf_mkString("struct"));
 }
 
+static int rdyncall_mode_from_signature_char(char ch)
+{
+  switch(ch)
+  {
+    case DC_SIGCHAR_CC_DEFAULT:
+      return DC_CALL_C_DEFAULT;
+    case DC_SIGCHAR_CC_ELLIPSIS:
+      return DC_CALL_C_ELLIPSIS;
+    case DC_SIGCHAR_CC_ELLIPSIS_VARARGS:
+      return DC_CALL_C_ELLIPSIS_VARARGS;
+    case DC_SIGCHAR_CC_STDCALL:
+      return DC_CALL_C_X86_WIN32_STD;
+    case DC_SIGCHAR_CC_FASTCALL_GNU:
+      return DC_CALL_C_X86_WIN32_FAST_GNU;
+    case DC_SIGCHAR_CC_FASTCALL_MS:
+      return DC_CALL_C_X86_WIN32_FAST_MS;
+    default:
+      Rf_error("Unknown calling convention prefix hint signature character '%c'", ch);
+      return DC_CALL_C_DEFAULT;
+  }
+}
+
 /** ---------------------------------------------------------------------------
  ** C-Function: C_dyncall
  ** R-Interface: .External
@@ -320,20 +342,7 @@ SEXP C_dyncall(SEXP args) /* callvm, address, signature, aggregate layouts, args
     /* specify calling convention by signature prefix hint */
     ++sig;
     char ch = *sig++;
-    int mode = DC_CALL_C_DEFAULT;
-    switch(ch)
-    {
-      case DC_SIGCHAR_CC_STDCALL:
-        mode = DC_CALL_C_X86_WIN32_STD; break;
-      case DC_SIGCHAR_CC_FASTCALL_GNU:
-        mode = DC_CALL_C_X86_WIN32_FAST_GNU; break;
-      case DC_SIGCHAR_CC_FASTCALL_MS:
-        mode = DC_CALL_C_X86_WIN32_FAST_MS; break;
-      default:
-        Rf_error("Unknown calling convention prefix hint signature character '%c'", ch );
-        /* dummy */ return R_NilValue;
-    }
-    dcMode(pvm, mode);
+    dcMode(pvm, rdyncall_mode_from_signature_char(ch));
   }
 
   if (aggr_return_layout != R_NilValue) {
@@ -351,6 +360,17 @@ SEXP C_dyncall(SEXP args) /* callvm, address, signature, aggregate layouts, args
     }
     /* argument terminator */
     if (ch == ')') break;
+
+    if (ch == DC_SIGCHAR_CC_PREFIX) {
+      char mode_ch = *sig++;
+      if (mode_ch == '\0') {
+        Rf_error("Function-call signature '%s' is invalid - missing calling convention mode character.", signature);
+        return R_NilValue; /* dummy */
+      }
+      dcMode(pvm, rdyncall_mode_from_signature_char(mode_ch));
+      ptrcnt = 0;
+      continue;
+    }
 
     /* end of arguments? */
     if (args == R_NilValue) {


### PR DESCRIPTION
## Summary
Add a low-level entry point for calling C functions declared with `...` while keeping call-site vararg types explicit.

## Changes
- Export `dyncall_variadic()` as a companion to `dyncall()`.
- Build the dyncall ellipsis signature from a fixed function prefix and a per-call vararg signature.
- Teach the C call bridge to switch dyncall modes inside a signature when entering the vararg portion.
- Add tinytest coverage with integer and double variadic fixture functions.

## Out of scope
- `dynbind()` wrapper generation for variadic functions.
- DynPort `Variadic` entries and generated R API dynports.
