### PR TITLE
feat: bind C variadic functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Generate real on-disk R packages from DCF DynPort files via `dynport()`.
 - Add `dyncall_variadic()` for calling C variadic functions with explicit
   call-site vararg signatures.
+- Allow `dynbind()` to generate wrappers for C variadic functions.
 - Allow `dynbind()` to accept direct library paths and existing external
   pointer handles in addition to short library names.
 - Improve `dynfind()` discovery for libraries installed by common package

--- a/R/dynbind.R
+++ b/R/dynbind.R
@@ -58,6 +58,12 @@
 #' `<TARGET>` is replaced with the expression `unpack(<TARGET>,"p",0)` in order
 #' to dereference `<TARGET>` as a pointer-to-function variable at call-time.
 #'
+#' C variadic functions can be bound by setting `variadic` to `TRUE`. In that
+#' case the library signature describes only the fixed argument prefix and
+#' return type. The generated wrapper accepts an additional named `.varargs`
+#' argument containing the type signatures for the values passed through `...`
+#' at that call site.
+#'
 #' @param libnames character vector or external pointer handle specifying the
 #'        shared library. Character values that contain a path separator, or
 #'        name an existing file, are passed directly to [dynload()]. Other
@@ -81,6 +87,10 @@
 #' @param funcptr logical, that indicates whether foreign objects refer to
 #'        functions (`FALSE`, default) or to function pointer variables
 #'        (`TRUE` rarely needed).
+#'
+#' @param variadic logical, indicating whether the foreign objects are C
+#'        variadic functions. Variadic wrappers require a named `.varargs`
+#'        argument at call time when values are passed through C `...`.
 #'
 #' @return
 #' The function returns a list with two fields:
@@ -110,7 +120,20 @@
 #' @keywords programming interface
 #' @export
 # TODO: use named character vector for signatures?
-dynbind <- function(libnames, signature, envir = parent.frame(), callmode = "default", pattern = NULL, replace = NULL, funcptr = FALSE) {
+dynbind <- function(libnames, signature, envir = parent.frame(), callmode = "default", pattern = NULL, replace = NULL, funcptr = FALSE, variadic = FALSE) {
+    if (!is.logical(funcptr) || length(funcptr) != 1L || is.na(funcptr)) {
+        stop("'funcptr' must be TRUE or FALSE.", call. = FALSE)
+    }
+    if (!is.logical(variadic) || length(variadic) != 1L || is.na(variadic)) {
+        stop("'variadic' must be TRUE or FALSE.", call. = FALSE)
+    }
+    if (funcptr && variadic) {
+        stop("'funcptr' and 'variadic' cannot both be TRUE.", call. = FALSE)
+    }
+    if (variadic && !callmode %in% c("default", "cdecl")) {
+        stop("variadic bindings currently support only the default C calling convention.", call. = FALSE)
+    }
+
     # load shared library
     libh <- dynbind_resolve_libhandle(libnames)
     if (is.null(libh)) {
@@ -149,7 +172,13 @@ dynbind <- function(libnames, signature, envir = parent.frame(), callmode = "def
         if (!is.null(address)) {
             # make call function f
             f <- function(...) NULL
-            if (funcptr) {
+            if (variadic) {
+                formals(f) <- alist(... = , .varargs = "")
+                body(f) <- substitute(
+                    dyncall_variadic(address, signature, .varargs, ...),
+                    list(address = address, signature = signature)
+                )
+            } else if (funcptr) {
                 body(f) <- substitute(
                     dyncallfunc(unpack(address, 0, "p"), signature, ...),
                     list(dyncallfunc = dyncallfunc, address = address, signature = signature)
@@ -201,7 +230,7 @@ dynbind_resolve_libhandle <- function(libnames) {
 }
 
 dynbind_is_library_path <- function(libname) {
-    !is.na(libname) && (grepl("[/\\\\]", libname) || file.exists(libname))
+    !is.na(libname) && (grepl("[/\\\\]", libname) || (file.exists(libname) && !dir.exists(libname)))
 }
 
 dynbind_libnames_label <- function(libnames) {

--- a/inst/tinytest/test_dynbind.R
+++ b/inst/tinytest/test_dynbind.R
@@ -53,10 +53,33 @@ expect_error(
     "argument type signatures"
 )
 
+env <- new.env()
+bind <- dynbind(fixture, "rdyncall_dynbind_sum_variadic(i)i;", envir = env, variadic = TRUE)
+expect_equal(class(bind), "dynbind.report")
+expect_equal(env$rdyncall_dynbind_sum_variadic(1L, 2L, 3L, .varargs = "ii"), 6L)
+expect_error(
+    dynbind(fixture, "rdyncall_dynbind_sum_variadic(i)i;", funcptr = TRUE, variadic = TRUE),
+    "cannot both be TRUE"
+)
+
 local({
     oldwd <- setwd(dirname(fixture))
     on.exit(setwd(oldwd), add = TRUE)
     expect_dynbind_add(file.path(".", basename(fixture)))
+})
+
+local({
+    if (!is.null(dynfind("R"))) {
+        tmp <- tempfile("rdyncall-dynbind-short-name-")
+        dir.create(file.path(tmp, "R"), recursive = TRUE)
+        oldwd <- setwd(tmp)
+        on.exit(setwd(oldwd), add = TRUE)
+
+        env <- new.env()
+        bind <- dynbind("R", "R_IsNA(d)i;", envir = env)
+        expect_equal(class(bind), "dynbind.report")
+        expect_equal(env$R_IsNA(NA_real_), 1L)
+    }
 })
 
 attr(handle, "dynbind-test") <- "input-handle"

--- a/man/dynbind.Rd
+++ b/man/dynbind.Rd
@@ -11,7 +11,8 @@ dynbind(
   callmode = "default",
   pattern = NULL,
   replace = NULL,
-  funcptr = FALSE
+  funcptr = FALSE,
+  variadic = FALSE
 )
 }
 \arguments{
@@ -39,6 +40,10 @@ part of symbolic names.}
 \item{funcptr}{logical, that indicates whether foreign objects refer to
 functions (\code{FALSE}, default) or to function pointer variables
 (\code{TRUE} rarely needed).}
+
+\item{variadic}{logical, indicating whether the foreign objects are C
+variadic functions. Variadic wrappers require a named \code{.varargs}
+argument at call time when values are passed through C \code{...}.}
 }
 \value{
 The function returns a list with two fields:
@@ -107,6 +112,12 @@ As a special case, \code{\link[=dynbind]{dynbind()}} supports binding of pointer
 variables, indicated by setting \code{funcptr} to \code{TRUE}, in which case
 \verb{<TARGET>} is replaced with the expression \verb{unpack(<TARGET>,"p",0)} in order
 to dereference \verb{<TARGET>} as a pointer-to-function variable at call-time.
+
+C variadic functions can be bound by setting \code{variadic} to \code{TRUE}. In that
+case the library signature describes only the fixed argument prefix and
+return type. The generated wrapper accepts an additional named \code{.varargs}
+argument containing the type signatures for the values passed through \code{...}
+at that call site.
 }
 \examples{
 \donttest{


### PR DESCRIPTION
## Summary
Teach `dynbind()` to expose C variadic functions through generated R wrappers.

## Changes
- Add the `variadic` argument to `dynbind()`.
- Generate wrappers that forward fixed arguments and named `.varargs` signatures to `dyncall_variadic()`.
- Reject incompatible `funcptr = TRUE, variadic = TRUE` requests.
- Avoid treating an existing directory with a short library name as a direct library file path.

## Out of scope
- DynPort `Variadic` entries.
- Generated R API dynport assets.
