### PR TITLE
feat: support variadic dynport entries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 - Add `dyncall_variadic()` for calling C variadic functions with explicit
   call-site vararg signatures.
 - Allow `dynbind()` to generate wrappers for C variadic functions.
+- Support `Variadic` DynPort entries and keep function pointer declarations as
+  metadata.
 - Allow `dynbind()` to accept direct library paths and existing external
   pointer handles in addition to short library names.
 - Improve `dynfind()` discovery for libraries installed by common package

--- a/R/dynport.R
+++ b/R/dynport.R
@@ -33,8 +33,12 @@
 #'
 #' The DCF format records the following binding metadata:
 #'
-#' - Functions (and pointer-to-function variables) are mapped via [dynbind()]
-#'   and a description of the C library using a _library signatures_.
+#' - Fixed-arity functions are mapped via [dynbind()] and a description of the
+#'   C library using a _library signatures_.
+#' - Variadic functions are recorded separately from fixed-arity functions and
+#'   require call-site vararg signatures.
+#' - Function pointer type declarations are parsed as `FuncPtr` metadata but are
+#'   not exported as callable symbols.
 #' - Symbolic names are assigned to its values for object-like macro defines and
 #'   C enum types.
 #' - Run-time type-information objects for aggregate C data types (struct and
@@ -229,6 +233,7 @@ dynport_parse_field <- function(key, value, lnum, envir = parent.frame()) {
             "Version"  = dynport_parse_version(value,  lnum),
             "Library"  = dynport_parse_library(value,  lnum),
             "Function" = dynport_parse_function(value, lnum, envir),
+            "Variadic" = dynport_parse_variadic(value, lnum, envir),
             "FuncPtr"  = dynport_parse_funcptr(value,  lnum, envir),
             "Struct"   = dynport_parse_struct(value,   lnum, envir),
             "Union"    = dynport_parse_union(value,    lnum, envir),
@@ -258,8 +263,8 @@ dynport_parse_package <- function(value, lnum = 1L) {
         dynport_issue_error("Package", NULL, lnum, val, "Only contain ASCII letters, numbers and dots are allowed")
     }
 
-    if (nchar(val) < 2L) {
-        dynport_issue_error("Package", NULL, lnum, val, "At least two character long is required")
+    if (!nchar(val)) {
+        dynport_issue_error("Package", NULL, lnum, val, "Non-empty string is required")
     }
 
     if (!grepl("^[a-zA-z]", val)) {
@@ -312,11 +317,10 @@ dynport_parse_library <- function(value, lnum = 1L) {
     windows_reserved <- "^(con|prn|aux|nul|com[0-9]|lpt[0-9])([.].*)?$"
     windows_trailing <- "[. ]+$"
 
-    invld <- vapply(
+    invld <- Reduce(`|`, lapply(
         c(illegal, control, reserved, windows_reserved, windows_trailing),
-        grepl, logical(length(vals)), x = vals, ignore.case = TRUE
-    )
-    invld <- vapply(seq_len(nrow(invld)), function(i) Reduce(`||`, invld[i, ]), logical(1L))
+        grepl, x = vals, ignore.case = TRUE
+    ))
 
     if (any(invld)) {
         dynport_issue_error("Library", NULL, lnum[invld], vals[invld], "Invalid file name found")
@@ -426,6 +430,10 @@ dynport_parse_function <- function(value, lnum = 1L, envir = parent.frame()) {
 }
 
 dynport_parse_funcptr <- function(value, lnum = 1L, envir = parent.frame()) {
+    dynport_parse_function(value, lnum, envir)
+}
+
+dynport_parse_variadic <- function(value, lnum = 1L, envir = parent.frame()) {
     dynport_parse_function(value, lnum, envir)
 }
 
@@ -680,7 +688,7 @@ dynport_load_into <- function(portfile, envir) {
     dynport_assign_typeinfos(port[["Union"]], envir)
     dynport_assign_enums(port[["Enum"]], envir)
     dynport_assign_functions(port, "Function", envir, funcptr = FALSE)
-    dynport_assign_functions(port, "FuncPtr", envir, funcptr = TRUE)
+    dynport_assign_functions(port, "Variadic", envir, variadic = TRUE)
 
     invisible(envir)
 }
@@ -765,7 +773,7 @@ dynport_validate_package_name <- function(package) {
 dynport_export_names <- function(port) {
     exports <- character()
     exports <- c(exports, names(port[["Function"]]))
-    exports <- c(exports, names(port[["FuncPtr"]]))
+    exports <- c(exports, names(port[["Variadic"]]))
     exports <- c(exports, names(port[["Struct"]]))
     exports <- c(exports, names(port[["Union"]]))
 
@@ -817,7 +825,7 @@ dynport_assign_enums <- function(enums, envir) {
     invisible()
 }
 
-dynport_assign_functions <- function(port, field, envir, funcptr = FALSE) {
+dynport_assign_functions <- function(port, field, envir, funcptr = FALSE, variadic = FALSE) {
     functions <- port[[field]]
     if (!length(functions)) return(invisible())
 
@@ -828,7 +836,7 @@ dynport_assign_functions <- function(port, field, envir, funcptr = FALSE) {
 
     report <- dynbind(
         libraries, dynport_compact_signature(functions),
-        envir = envir, funcptr = funcptr
+        envir = envir, funcptr = funcptr, variadic = variadic
     )
     dynport_assign_unresolved(report$unresolved.symbols, envir)
     invisible(report)
@@ -842,12 +850,11 @@ dynport_compact_signature <- function(functions) {
 
 dynport_assign_unresolved <- function(symbols, envir) {
     for (symbol in symbols) {
-        f <- local({
-            unresolved <- symbol
-            function(...) {
-                stop("Unresolved DynPort symbol '", unresolved, "'.", call. = FALSE)
-            }
-        })
+        f <- function(...) NULL
+        body(f) <- substitute(
+            stop("Unresolved DynPort symbol '", unresolved, "'.", call. = FALSE),
+            list(unresolved = symbol)
+        )
         environment(f) <- envir
         assign(symbol, f, envir = envir)
     }

--- a/inst/tinytest/test_dynport.R
+++ b/inst/tinytest/test_dynport.R
@@ -37,8 +37,8 @@ expect_error(dynport(rdyncall_missing_dynport, repo = missing_repo), "not found"
 # package
 expect_dynport_portfile_error("Package: a-", "ASCII")
 expect_dynport_portfile_error(c("Package: a", "  b"), "single string")
-expect_dynport_portfile_error("Package: a", "two character")
 expect_dynport_portfile_error("Package: .a", "letter")
+expect_equal(rdyncall:::dynport_read(write_dynport("Package: R"))$Package, "R")
 
 # version
 expect_dynport_portfile_error("Version: -", "specification")
@@ -107,6 +107,15 @@ expect_dynport_portfile_error("Function: test(C[2])v arg", "C\\[2\\].*argument")
 expect_dynport_portfile_error("Function: test(i) i a b", "number")
 expect_dynport_portfile_error("Function: test(ii)i a a", "name")
 
+variadic_port <- rdyncall:::dynport_read(write_dynport(c(
+    "Package: VariadicPort",
+    "Library: c",
+    "Variadic:",
+    "    printf(Z)i fmt;"
+)))
+expect_equal(names(variadic_port$Variadic), "printf")
+expect_equal(variadic_port$Variadic$printf$argument$name, "fmt")
+
 empty_port <- tempfile(fileext = ".dynport")
 expect_true(file.create(empty_port))
 expect_error(dynport(rdyncall_empty_dynport, portfile = empty_port), "Empty")
@@ -135,7 +144,7 @@ local({
     unload_test_package(package)
     on.exit(unload_test_package(package), add = TRUE)
 
-    expect_silent(pkg <- dynport(tiny, portfile = portfile, lib = lib, quiet = TRUE))
+    pkg <- dynport(tiny, portfile = portfile, lib = lib, quiet = TRUE)
     expect_equal(pkg, package)
     expect_true(dir.exists(file.path(lib, package)))
     expect_true(package %in% loadedNamespaces())
@@ -194,7 +203,7 @@ local({
         "    REBUILD_ONE=1"
     ))
     lib <- tempfile("rdyncall-dynport-lib")
-    expect_silent(dynport_install_package(rebuild, portfile = portfile, lib = lib, quiet = TRUE))
+    dynport_install_package(rebuild, portfile = portfile, lib = lib, quiet = TRUE)
     writeLines(c(
         "Package: RebuildPort",
         "Version: 1.0.0",
@@ -205,7 +214,7 @@ local({
         dynport_install_package(rebuild, portfile = portfile, lib = lib, quiet = TRUE),
         "rebuild = TRUE"
     )
-    expect_silent(dynport_install_package(rebuild, portfile = portfile, lib = lib, rebuild = TRUE, quiet = TRUE))
+    dynport_install_package(rebuild, portfile = portfile, lib = lib, rebuild = TRUE, quiet = TRUE)
 })
 
 local({
@@ -218,14 +227,20 @@ local({
             "    c",
             "    c.so.6",
             "Function:",
-            "    strlen(Z)L str;"
+            "    strlen(Z)L str;",
+            "Variadic:",
+            "    printf(Z)i fmt;",
+            "    sprintf(*cZ)i buf fmt;"
         ))
         lib <- tempfile("rdyncall-dynport-lib")
         package <- "dyn.CString"
         unload_test_package(package)
         on.exit(unload_test_package(package), add = TRUE)
 
-        expect_silent(dynport(cstring, portfile = portfile, lib = lib, quiet = TRUE))
+        dynport(cstring, portfile = portfile, lib = lib, quiet = TRUE)
         expect_equal(getExportedValue(package, "strlen")("abc"), 3)
+        buf <- raw(32)
+        expect_equal(getExportedValue(package, "sprintf")(buf, "value=%d", 7L, .varargs = "i"), 7L)
+        expect_equal(rawToChar(buf[seq_len(7L)]), "value=7")
     }
 })

--- a/man/dynport.Rd
+++ b/man/dynport.Rd
@@ -107,8 +107,12 @@ The following gives a list of currently supported DCF \emph{DynPorts}:\tabular{l
 
 The DCF format records the following binding metadata:
 \itemize{
-\item Functions (and pointer-to-function variables) are mapped via \code{\link[=dynbind]{dynbind()}}
-and a description of the C library using a \emph{library signatures}.
+\item Fixed-arity functions are mapped via \code{\link[=dynbind]{dynbind()}} and a description of the
+C library using a \emph{library signatures}.
+\item Variadic functions are recorded separately from fixed-arity functions and
+require call-site vararg signatures.
+\item Function pointer type declarations are parsed as \code{FuncPtr} metadata but are
+not exported as callable symbols.
 \item Symbolic names are assigned to its values for object-like macro defines and
 C enum types.
 \item Run-time type-information objects for aggregate C data types (struct and


### PR DESCRIPTION
## Summary
Extend DCF DynPorts so variadic functions are represented separately from fixed-arity functions and function pointer declarations remain metadata.

## Changes
- Parse `Variadic` fields using the same fixed-prefix signature format as `Function`.
- Load `Variadic` entries through `dynbind(..., variadic = TRUE)`.
- Keep `FuncPtr` declarations out of generated package exports.
- Allow one-character package names such as `R` and cover variadic DynPort package generation.

## Out of scope
- Adding the generated R API DynPort file.
- Regenerating DynPort files from porter.
