### PR TITLE
feat: add R API dynport

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - Allow `dynbind()` to generate wrappers for C variadic functions.
 - Support `Variadic` DynPort entries and keep function pointer declarations as
   metadata.
+- Add a generated DCF DynPort for the R API.
 - Allow `dynbind()` to accept direct library paths and existing external
   pointer handles in addition to short library names.
 - Improve `dynfind()` discovery for libraries installed by common package

--- a/R/dynport.R
+++ b/R/dynport.R
@@ -29,6 +29,7 @@
 #'
 #' | **DynPort name/C library** | **Description**                                 |
 #' |:---------------------------|:------------------------------------------------|
+#' | `R`                        | R API                                           |
 #' | `SDL2`                     | Simple DirectMedia Layer 2                      |
 #'
 #' The DCF format records the following binding metadata:

--- a/inst/dynports/R.dynport
+++ b/inst/dynports/R.dynport
@@ -1,0 +1,311 @@
+Package: R
+Version: 3.1.0
+Library: R
+Function:
+    R_IsNA(d)i X;
+    R_IsNaN(d)i X;
+    R_finite(d)i X;
+    UNIMPLEMENTED(Z)v X;
+    R_ShowMessage(Z)v s;
+    vmaxget()p;
+    vmaxset(p)v X;
+    R_gc()v;
+    R_alloc(Ji)*c X Y;
+    S_alloc(ji)*c X Y;
+    S_realloc(*cjji)*c X Y Z U;
+    Rvprintf(Z*c)v X Y;
+    REvprintf(Z*c)v X Y;
+    GetRNGstate()v;
+    PutRNGstate()v;
+    unif_rand()d;
+    norm_rand()d;
+    exp_rand()d;
+    user_unif_rand()*d;
+    user_unif_init(I)v X;
+    user_unif_nseed()*i;
+    user_unif_seedloc()*i;
+    user_norm_rand()*d;
+    R_isort(*ii)v X Y;
+    R_rsort(*di)v X Y;
+    R_csort(*<Rcomplex>i)v X Y;
+    rsort_with_index(*d*ii)v X Y Z;
+    Rf_revsort(*d*ii)v X Y Z;
+    Rf_iPsort(*iii)v X Y Z;
+    Rf_rPsort(*dii)v X Y Z;
+    Rf_cPsort(*<Rcomplex>ii)v X Y Z;
+    R_qsort(*dJJ)v v i j;
+    R_qsort_I(*d*iii)v v II i j;
+    R_qsort_int(*iJJ)v iv i j;
+    R_qsort_int_I(*i*iii)v iv II i j;
+    R_ExpandFileName(Z)Z X;
+    Rf_StringFalse(Z)<Rboolean> X;
+    Rf_StringTrue(Z)<Rboolean> X;
+    Rf_isBlankString(Z)<Rboolean> X;
+    R_atof(Z)d str;
+    R_strtod(Zp)d c end;
+    R_tmpnam(ZZ)*c prefix tempdir;
+    R_tmpnam2(ZZZ)*c prefix tempdir fileext;
+    R_CheckUserInterrupt()v;
+    R_CheckStack()v;
+    R_CheckStack2(J)v X;
+    findInterval(*did<Rboolean><Rboolean>i*i)i xt n x rightmost_closed all_inside ilo mflag;
+    R_max_col(*d*i*i*i*i)v matrix nr nc maxes ties_meth;
+    R_chk_calloc(JJ)p X Y;
+    R_chk_realloc(pJ)p X Y;
+    R_chk_free(p)v X;
+    R_FlushConsole()v;
+    R_ProcessEvents()v;
+    R_CHAR(*<SEXPREC>)Z x;
+    Rf_isNull(*<SEXPREC>)<Rboolean> s;
+    Rf_isSymbol(*<SEXPREC>)<Rboolean> s;
+    Rf_isLogical(*<SEXPREC>)<Rboolean> s;
+    Rf_isReal(*<SEXPREC>)<Rboolean> s;
+    Rf_isComplex(*<SEXPREC>)<Rboolean> s;
+    Rf_isExpression(*<SEXPREC>)<Rboolean> s;
+    Rf_isEnvironment(*<SEXPREC>)<Rboolean> s;
+    Rf_isString(*<SEXPREC>)<Rboolean> s;
+    Rf_isObject(*<SEXPREC>)<Rboolean> s;
+    TYPEOF(*<SEXPREC>)i x;
+    DUPLICATE_ATTRIB(*<SEXPREC>*<SEXPREC>)v to from;
+    LENGTH(*<SEXPREC>)i x;
+    XLENGTH(*<SEXPREC>)j x;
+    IS_LONG_VEC(*<SEXPREC>)i x;
+    LOGICAL(*<SEXPREC>)*i x;
+    INTEGER(*<SEXPREC>)*i x;
+    RAW(*<SEXPREC>)*C x;
+    REAL(*<SEXPREC>)*d x;
+    COMPLEX(*<SEXPREC>)*<Rcomplex> x;
+    STRING_ELT(*<SEXPREC>j)*<SEXPREC> x i;
+    VECTOR_ELT(*<SEXPREC>j)*<SEXPREC> x i;
+    SET_STRING_ELT(*<SEXPREC>j*<SEXPREC>)v x i v;
+    SET_VECTOR_ELT(*<SEXPREC>j*<SEXPREC>)*<SEXPREC> x i v;
+    TAG(*<SEXPREC>)*<SEXPREC> e;
+    CAR(*<SEXPREC>)*<SEXPREC> e;
+    CDR(*<SEXPREC>)*<SEXPREC> e;
+    CAAR(*<SEXPREC>)*<SEXPREC> e;
+    CDAR(*<SEXPREC>)*<SEXPREC> e;
+    CADR(*<SEXPREC>)*<SEXPREC> e;
+    CDDR(*<SEXPREC>)*<SEXPREC> e;
+    CADDR(*<SEXPREC>)*<SEXPREC> e;
+    CADDDR(*<SEXPREC>)*<SEXPREC> e;
+    CAD4R(*<SEXPREC>)*<SEXPREC> e;
+    SET_TAG(*<SEXPREC>*<SEXPREC>)v x y;
+    SETCAR(*<SEXPREC>*<SEXPREC>)*<SEXPREC> x y;
+    SETCDR(*<SEXPREC>*<SEXPREC>)*<SEXPREC> x y;
+    SETCADR(*<SEXPREC>*<SEXPREC>)*<SEXPREC> x y;
+    SETCADDR(*<SEXPREC>*<SEXPREC>)*<SEXPREC> x y;
+    SETCADDDR(*<SEXPREC>*<SEXPREC>)*<SEXPREC> x y;
+    SETCAD4R(*<SEXPREC>*<SEXPREC>)*<SEXPREC> e y;
+    PRINTNAME(*<SEXPREC>)*<SEXPREC> x;
+    R_GetCurrentSrcref(i)*<SEXPREC> X;
+    R_GetSrcFilename(*<SEXPREC>)*<SEXPREC> X;
+    Rf_asChar(*<SEXPREC>)*<SEXPREC> X;
+    Rf_coerceVector(*<SEXPREC>I)*<SEXPREC> X Y;
+    Rf_PairToVectorList(*<SEXPREC>)*<SEXPREC> x;
+    Rf_VectorToPairList(*<SEXPREC>)*<SEXPREC> x;
+    Rf_asCharacterFactor(*<SEXPREC>)*<SEXPREC> x;
+    Rf_asLogical(*<SEXPREC>)i x;
+    Rf_asInteger(*<SEXPREC>)i x;
+    Rf_asReal(*<SEXPREC>)d x;
+    Rf_acopy_string(Z)*c X;
+    Rf_alloc3DArray(Iiii)*<SEXPREC> X Y Z U;
+    Rf_allocArray(I*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_allocMatrix(Iii)*<SEXPREC> X Y Z;
+    Rf_allocList(i)*<SEXPREC> X;
+    Rf_allocS4Object()*<SEXPREC>;
+    Rf_any_duplicated(*<SEXPREC><Rboolean>)j x from_last;
+    Rf_any_duplicated3(*<SEXPREC>*<SEXPREC><Rboolean>)j x incomp from_last;
+    Rf_classgets(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_cons(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_copyMatrix(*<SEXPREC>*<SEXPREC><Rboolean>)v X Y Z;
+    Rf_copyListMatrix(*<SEXPREC>*<SEXPREC><Rboolean>)v X Y Z;
+    Rf_copyMostAttrib(*<SEXPREC>*<SEXPREC>)v X Y;
+    Rf_copyVector(*<SEXPREC>*<SEXPREC>)v X Y;
+    Rf_defineVar(*<SEXPREC>*<SEXPREC>*<SEXPREC>)v X Y Z;
+    Rf_dimgets(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_dimnamesgets(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_duplicate(*<SEXPREC>)*<SEXPREC> X;
+    Rf_shallow_duplicate(*<SEXPREC>)*<SEXPREC> X;
+    Rf_duplicated(*<SEXPREC><Rboolean>)*<SEXPREC> X Y;
+    Rf_eval(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_findFun(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_getAttrib(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_GetArrayDimnames(*<SEXPREC>)*<SEXPREC> X;
+    Rf_GetColNames(*<SEXPREC>)*<SEXPREC> X;
+    Rf_GetMatrixDimnames(*<SEXPREC>pppp)v X Y Z U V;
+    Rf_GetOption1(*<SEXPREC>)*<SEXPREC> X;
+    Rf_GetOptionWidth()i;
+    Rf_GetRowNames(*<SEXPREC>)*<SEXPREC> X;
+    Rf_install(Z)*<SEXPREC> X;
+    Rf_isOrdered(*<SEXPREC>)<Rboolean> X;
+    Rf_isUnordered(*<SEXPREC>)<Rboolean> X;
+    Rf_isUnsorted(*<SEXPREC><Rboolean>)<Rboolean> X Y;
+    Rf_lengthgets(*<SEXPREC>i)*<SEXPREC> X Y;
+    Rf_xlengthgets(*<SEXPREC>j)*<SEXPREC> X Y;
+    Rf_match(*<SEXPREC>*<SEXPREC>i)*<SEXPREC> X Y Z;
+    Rf_namesgets(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_mkChar(Z)*<SEXPREC> X;
+    Rf_mkCharLen(Zi)*<SEXPREC> X Y;
+    Rf_ncols(*<SEXPREC>)i X;
+    Rf_nrows(*<SEXPREC>)i X;
+    Rf_nthcdr(*<SEXPREC>i)*<SEXPREC> X Y;
+    Rf_pmatch(*<SEXPREC>*<SEXPREC><Rboolean>)<Rboolean> X Y Z;
+    Rf_psmatch(ZZ<Rboolean>)<Rboolean> X Y Z;
+    Rf_PrintValue(*<SEXPREC>)v X;
+    Rf_setAttrib(*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y Z;
+    Rf_setVar(*<SEXPREC>*<SEXPREC>*<SEXPREC>)v X Y Z;
+    Rf_str2type(Z)I X;
+    Rf_StringBlank(*<SEXPREC>)<Rboolean> X;
+    Rf_translateChar(*<SEXPREC>)Z X;
+    Rf_translateCharUTF8(*<SEXPREC>)Z X;
+    Rf_type2char(I)Z X;
+    Rf_type2str(I)*<SEXPREC> X;
+    Rf_unprotect_ptr(*<SEXPREC>)v X;
+    R_tryEval(*<SEXPREC>*<SEXPREC>*i)*<SEXPREC> X Y Z;
+    R_tryEvalSilent(*<SEXPREC>*<SEXPREC>*i)*<SEXPREC> X Y Z;
+    R_curErrorBuf()Z;
+    Rf_isS4(*<SEXPREC>)<Rboolean> X;
+    Rf_asS4(*<SEXPREC><Rboolean>i)*<SEXPREC> X Y Z;
+    Rf_getCharCE(*<SEXPREC>)<cetype_t> X;
+    Rf_mkCharCE(Z<cetype_t>)*<SEXPREC> X Y;
+    Rf_mkCharLenCE(Zi<cetype_t>)*<SEXPREC> X Y Z;
+    Rf_reEnc(Z<cetype_t><cetype_t>i)Z x ce_in ce_out subst;
+    R_MakeExternalPtr(p*<SEXPREC>*<SEXPREC>)*<SEXPREC> p tag prot;
+    R_ExternalPtrAddr(*<SEXPREC>)p s;
+    R_ExternalPtrTag(*<SEXPREC>)*<SEXPREC> s;
+    R_ExternalPtrProtected(*<SEXPREC>)*<SEXPREC> s;
+    R_ClearExternalPtr(*<SEXPREC>)v s;
+    R_SetExternalPtrAddr(*<SEXPREC>p)v s p;
+    R_SetExternalPtrTag(*<SEXPREC>*<SEXPREC>)v s tag;
+    R_SetExternalPtrProtected(*<SEXPREC>*<SEXPREC>)v s p;
+    R_RegisterFinalizer(*<SEXPREC>*<SEXPREC>)v s fun;
+    R_RegisterCFinalizer(*<SEXPREC>p)v s fun;
+    R_RegisterFinalizerEx(*<SEXPREC>*<SEXPREC><Rboolean>)v s fun onexit;
+    R_RegisterCFinalizerEx(*<SEXPREC>p<Rboolean>)v s fun onexit;
+    R_RunPendingFinalizers()v;
+    R_MakeWeakRef(*<SEXPREC>*<SEXPREC>*<SEXPREC><Rboolean>)*<SEXPREC> key val fin onexit;
+    R_MakeWeakRefC(*<SEXPREC>*<SEXPREC>p<Rboolean>)*<SEXPREC> key val fin onexit;
+    R_WeakRefKey(*<SEXPREC>)*<SEXPREC> w;
+    R_WeakRefValue(*<SEXPREC>)*<SEXPREC> w;
+    R_RunWeakRefFinalizer(*<SEXPREC>)v w;
+    R_ClosureExpr(*<SEXPREC>)*<SEXPREC> X;
+    R_ToplevelExec(pp)<Rboolean> fun data;
+    R_ExecWithCleanup(pppp)*<SEXPREC> fun data cleanfun cleandata;
+    R_IsPackageEnv(*<SEXPREC>)<Rboolean> rho;
+    R_PackageEnvName(*<SEXPREC>)*<SEXPREC> rho;
+    R_IsNamespaceEnv(*<SEXPREC>)<Rboolean> rho;
+    R_NamespaceEnvSpec(*<SEXPREC>)*<SEXPREC> rho;
+    R_FindNamespace(*<SEXPREC>)*<SEXPREC> info;
+    R_LockEnvironment(*<SEXPREC><Rboolean>)v env bindings;
+    R_EnvironmentIsLocked(*<SEXPREC>)<Rboolean> env;
+    R_LockBinding(*<SEXPREC>*<SEXPREC>)v sym env;
+    R_unLockBinding(*<SEXPREC>*<SEXPREC>)v sym env;
+    R_MakeActiveBinding(*<SEXPREC>*<SEXPREC>*<SEXPREC>)v sym fun env;
+    R_BindingIsLocked(*<SEXPREC>*<SEXPREC>)<Rboolean> sym env;
+    R_BindingIsActive(*<SEXPREC>*<SEXPREC>)<Rboolean> sym env;
+    R_Serialize(*<SEXPREC>*<R_outpstream_st>)v s ops;
+    R_Unserialize(*<R_inpstream_st>)*<SEXPREC> ips;
+    R_do_slot(*<SEXPREC>*<SEXPREC>)*<SEXPREC> obj name;
+    R_do_slot_assign(*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> obj name value;
+    R_has_slot(*<SEXPREC>*<SEXPREC>)i obj name;
+    R_do_MAKE_CLASS(Z)*<SEXPREC> what;
+    R_getClassDef(Z)*<SEXPREC> what;
+    R_do_new_object(*<SEXPREC>)*<SEXPREC> class_def;
+    R_check_class_etc(*<SEXPREC>p)i x valid;
+    R_PreserveObject(*<SEXPREC>)v X;
+    R_ReleaseObject(*<SEXPREC>)v X;
+    R_dot_Last()v;
+    R_RunExitFinalizers()v;
+    R_compute_identical(*<SEXPREC>*<SEXPREC>i)<Rboolean> X Y Z;
+    R_orderVector(*ii*<SEXPREC><Rboolean><Rboolean>)v indx n arglist nalast decreasing;
+    Rf_allocVector(Ij)*<SEXPREC> X Y;
+    Rf_elt(*<SEXPREC>i)*<SEXPREC> X Y;
+    Rf_inherits(*<SEXPREC>Z)<Rboolean> X Y;
+    Rf_isArray(*<SEXPREC>)<Rboolean> X;
+    Rf_isFactor(*<SEXPREC>)<Rboolean> X;
+    Rf_isFunction(*<SEXPREC>)<Rboolean> X;
+    Rf_isInteger(*<SEXPREC>)<Rboolean> X;
+    Rf_isLanguage(*<SEXPREC>)<Rboolean> X;
+    Rf_isList(*<SEXPREC>)<Rboolean> X;
+    Rf_isMatrix(*<SEXPREC>)<Rboolean> X;
+    Rf_isNewList(*<SEXPREC>)<Rboolean> X;
+    Rf_isNumber(*<SEXPREC>)<Rboolean> X;
+    Rf_isNumeric(*<SEXPREC>)<Rboolean> X;
+    Rf_isPairList(*<SEXPREC>)<Rboolean> X;
+    Rf_isPrimitive(*<SEXPREC>)<Rboolean> X;
+    Rf_isTs(*<SEXPREC>)<Rboolean> X;
+    Rf_isVector(*<SEXPREC>)<Rboolean> X;
+    Rf_isVectorAtomic(*<SEXPREC>)<Rboolean> X;
+    Rf_isVectorList(*<SEXPREC>)<Rboolean> X;
+    Rf_isVectorizable(*<SEXPREC>)<Rboolean> X;
+    Rf_lang1(*<SEXPREC>)*<SEXPREC> X;
+    Rf_lang2(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_lang3(*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y Z;
+    Rf_lang4(*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y Z U;
+    Rf_lang5(*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y Z U V;
+    Rf_lang6(*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y Z U V W;
+    Rf_lastElt(*<SEXPREC>)*<SEXPREC> X;
+    Rf_lcons(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_length(*<SEXPREC>)i X;
+    Rf_list1(*<SEXPREC>)*<SEXPREC> X;
+    Rf_list2(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_list3(*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y Z;
+    Rf_list4(*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y Z U;
+    Rf_list5(*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y Z U V;
+    Rf_listAppend(*<SEXPREC>*<SEXPREC>)*<SEXPREC> X Y;
+    Rf_mkNamed(Ip)*<SEXPREC> X Y;
+    Rf_mkString(Z)*<SEXPREC> X;
+    Rf_nlevels(*<SEXPREC>)i X;
+    Rf_ScalarInteger(i)*<SEXPREC> X;
+    Rf_ScalarLogical(i)*<SEXPREC> X;
+    Rf_ScalarRaw(C)*<SEXPREC> X;
+    Rf_ScalarReal(d)*<SEXPREC> X;
+    Rf_ScalarString(*<SEXPREC>)*<SEXPREC> X;
+    Rf_xlength(*<SEXPREC>)j X;
+    Rf_protect(*<SEXPREC>)*<SEXPREC> X;
+    Rf_unprotect(i)v X;
+    R_ProtectWithIndex(*<SEXPREC>*i)v X Y;
+    R_Reprotect(*<SEXPREC>i)v X Y;
+Variadic:
+    Rf_error(Z)v X;
+    Rf_warning(Z)v X;
+    Rprintf(Z)v X;
+    REprintf(Z)v X;
+    Rf_errorcall(*<SEXPREC>Z)v X Y;
+    Rf_warningcall(*<SEXPREC>Z)v X Y;
+    Rf_warningcall_immediate(*<SEXPREC>Z)v X Y;
+FuncPtr:
+    OutPersistHookFunc(*<SEXPREC>*<SEXPREC>)*<SEXPREC>;
+    R_CFinalizer_t(*<SEXPREC>)v;
+    InChar(*<R_inpstream_st>)i;
+    InBytes(*<R_inpstream_st>pi)v;
+    OutChar(*<R_outpstream_st>i)v;
+    OutBytes(*<R_outpstream_st>pi)v;
+Enum/Rboolean:
+Enum/RNGtype:
+    WICHMANN_HILL=0
+    MARSAGLIA_MULTICARRY=1
+    SUPER_DUPER=2
+    MERSENNE_TWISTER=3
+    KNUTH_TAOCP=4
+    USER_UNIF=5
+    KNUTH_TAOCP2=6
+    LECUYER_CMRG=7
+Enum/N01type:
+    BUGGY_KINDERMAN_RAMAGE=0
+    AHRENS_DIETER=1
+    BOX_MULLER=2
+    USER_NORM=3
+    INVERSION=4
+    KINDERMAN_RAMAGE=5
+Enum/cetype_t:
+    CE_NATIVE=0
+    CE_UTF8=1
+    CE_LATIN1=2
+    CE_BYTES=3
+    CE_SYMBOL=5
+    CE_ANY=99
+Struct:
+    SEXPREC{};
+    R_allocator{};
+Union:

--- a/inst/tinytest/test_dynport.R
+++ b/inst/tinytest/test_dynport.R
@@ -130,6 +130,21 @@ sdl2 <- rdyncall:::dynport_read(sdl2_portfile)
 expect_equal(as.character(sdl2$Package), "SDL2")
 expect_true("SDL_mutex" %in% names(sdl2$Struct))
 
+r_portfile <- system.file("dynports", "R.dynport", package = "rdyncall", mustWork = TRUE)
+r_port <- rdyncall:::dynport_read(r_portfile)
+expect_equal(as.character(r_port$Package), "R")
+expect_equal(r_port$Library, "R")
+expect_true("R_IsNA" %in% names(r_port$Function))
+expect_true("R_finite" %in% names(r_port$Function))
+expect_true("R_atof" %in% names(r_port$Function))
+expect_true("Rprintf" %in% names(r_port$Variadic))
+expect_true("R_CFinalizer_t" %in% names(r_port$FuncPtr))
+expect_false("R_allocLD" %in% names(r_port$Function))
+expect_true("SEXPREC" %in% names(r_port$Struct))
+expect_false("Rcomplex" %in% names(r_port$Struct))
+expect_false("Rcomplex" %in% names(r_port$Union))
+expect_false(any(c("FALSE", "TRUE") %in% names(r_port$Enum$Rboolean)))
+
 local({
     portfile <- write_dynport(c(
         "Package: TinyPort",
@@ -242,5 +257,21 @@ local({
         buf <- raw(32)
         expect_equal(getExportedValue(package, "sprintf")(buf, "value=%d", 7L, .varargs = "i"), 7L)
         expect_equal(rawToChar(buf[seq_len(7L)]), "value=7")
+    }
+})
+
+local({
+    if (!is.null(dynfind("R"))) {
+        lib <- tempfile("rdyncall-r-dynport-lib")
+        package <- "dyn.R"
+        unload_test_package(package)
+        on.exit(unload_test_package(package), add = TRUE)
+
+        dynport(R, portfile = r_portfile, lib = lib, quiet = TRUE)
+        expect_equal(getExportedValue(package, "R_IsNA")(NA_real_), 1L)
+        expect_equal(getExportedValue(package, "R_finite")(1), 1L)
+        expect_equal(getExportedValue(package, "R_atof")("1.5"), 1.5)
+        expect_true(".varargs" %in% names(formals(getExportedValue(package, "Rprintf"))))
+        expect_false("DL_FUNC" %in% getNamespaceExports(package))
     }
 })

--- a/man/dynport.Rd
+++ b/man/dynport.Rd
@@ -101,6 +101,7 @@ name is explicitly supplied.
 
 The following gives a list of currently supported DCF \emph{DynPorts}:\tabular{ll}{
    \strong{DynPort name/C library} \tab \strong{Description} \cr
+   \code{R} \tab R API \cr
    \code{SDL2} \tab Simple DirectMedia Layer 2 \cr
 }
 

--- a/tools/dynports/generate-R.R
+++ b/tools/dynports/generate-R.R
@@ -1,0 +1,305 @@
+#!/usr/bin/env Rscript
+
+script_root <- function() {
+    cmd <- commandArgs(FALSE)
+    file_arg <- grep("^--file=", cmd, value = TRUE)
+    if (length(file_arg)) {
+        script <- normalizePath(sub("^--file=", "", file_arg[[1L]]), mustWork = TRUE)
+        normalizePath(file.path(dirname(script), "..", ".."), mustWork = TRUE)
+    } else {
+        normalizePath(".", mustWork = TRUE)
+    }
+}
+
+parse_args <- function(args) {
+    out <- list(
+        include = NULL,
+        version = NULL,
+        output = NULL,
+        snapshot = NULL,
+        intersect_with = NULL,
+        help = FALSE
+    )
+
+    for (arg in args) {
+        if (arg %in% c("-h", "--help")) {
+            out$help <- TRUE
+            next
+        }
+        if (!startsWith(arg, "--") || !grepl("=", arg, fixed = TRUE)) {
+            stop("Unsupported argument: ", arg, call. = FALSE)
+        }
+        key <- sub("^--", "", sub("=.*$", "", arg))
+        key <- gsub("-", "_", key, fixed = TRUE)
+        val <- sub("^[^=]*=", "", arg)
+        if (!key %in% names(out)) {
+            stop("Unknown option: --", gsub("_", "-", key, fixed = TRUE), call. = FALSE)
+        }
+        out[[key]] <- val
+    }
+
+    out
+}
+
+usage <- function() {
+    cat(
+        "Usage: Rscript tools/dynports/generate-R.R [options]\n",
+        "\n",
+        "Options:\n",
+        "  --include=DIR          R include directory. Defaults to R.home('include').\n",
+        "  --version=VERSION      Version stored in the dynport. Defaults to detected R version.\n",
+        "  --output=FILE          Output dynport path. Defaults to inst/dynports/R.dynport.\n",
+        "  --snapshot=FILE        Optional unfiltered dynport snapshot path.\n",
+        "  --intersect-with=FILE  Keep only entries also present in another dynport file.\n",
+        sep = ""
+    )
+}
+
+root <- script_root()
+args <- parse_args(commandArgs(TRUE))
+if (isTRUE(args$help)) {
+    usage()
+    quit(save = "no")
+}
+
+porter_repo <- Sys.getenv("PORTER_REPO", unset = "")
+if (nzchar(porter_repo)) {
+    porter_repo <- normalizePath(porter_repo, mustWork = TRUE)
+    if (!requireNamespace("pkgload", quietly = TRUE)) {
+        stop("Package 'pkgload' is required when PORTER_REPO is set.", call. = FALSE)
+    }
+    pkgload::load_all(porter_repo, quiet = TRUE)
+} else if (!requireNamespace("porter", quietly = TRUE)) {
+    sibling <- normalizePath(file.path(root, "..", "porter"), mustWork = FALSE)
+    if (dir.exists(sibling) && requireNamespace("pkgload", quietly = TRUE)) {
+        pkgload::load_all(sibling, quiet = TRUE)
+    }
+}
+if (!"porter" %in% loadedNamespaces()) {
+    stop("Package 'porter' is required to generate R.dynport.", call. = FALSE)
+}
+
+detect_r_version <- function(include) {
+    rversion <- file.path(include, "Rversion.h")
+    if (!file.exists(rversion)) return(as.character(getRversion()))
+
+    lines <- readLines(rversion, warn = FALSE)
+    get_define <- function(name) {
+        pat <- paste0('^#define[[:space:]]+', name, '[[:space:]]+"([^"]+)".*$')
+        hit <- grep(pat, lines, value = TRUE)
+        if (!length(hit)) return(NA_character_)
+        sub(pat, "\\1", hit[[1L]])
+    }
+    major <- get_define("R_MAJOR")
+    minor <- get_define("R_MINOR")
+    if (is.na(major) || is.na(minor)) as.character(getRversion()) else paste(major, minor, sep = ".")
+}
+
+read_dynport_values <- function(file) {
+    lines <- readLines(file, warn = FALSE)
+
+    con <- textConnection(lines, local = TRUE)
+    keys <- colnames(read.dcf(con))
+    close(con)
+
+    con <- textConnection(lines, local = TRUE)
+    dcf <- read.dcf(con, keep.white = keys)
+    close(con)
+
+    values <- as.list(dcf[1L, ])
+    names(values) <- keys
+    lapply(values, function(value) {
+        if (is.na(value)) return(character())
+        if (substr(value, 1L, 1L) == "\n") value <- substr(value, 2L, nchar(value))
+        value <- trimws(strsplit(value, "\n", fixed = TRUE)[[1L]])
+        value[nzchar(value)]
+    })
+}
+
+field_count <- function(port, field) {
+    value <- port[[field]]$value
+    if (is.null(value)) 0L else nrow(value)
+}
+
+intersect_simple_field <- function(port, reference, field) {
+    value <- port[[field]]$value
+    if (is.null(value) || !nrow(value)) return(port)
+
+    raw <- format(port[[field]], raw = TRUE)
+    keep <- raw %in% reference[[field]]
+    args <- list(value[keep, , drop = FALSE])
+    names(args) <- field
+    do.call(porter::port_set, c(list(port), args))
+}
+
+intersect_enum_field <- function(port, reference) {
+    value <- port$Enum$value
+    if (is.null(value) || !nrow(value)) return(port)
+
+    raw <- format(port$Enum, raw = TRUE)
+    keep <- vapply(seq_len(nrow(value)), function(i) {
+        name <- value$name[[i]]
+        ref <- reference[[paste0("Enum/", name)]]
+        if (is.null(ref) && !is.null(reference$Enum) && nrow(value) == 1L) {
+            ref <- reference$Enum
+        }
+        !is.null(ref) && identical(unname(raw[[name]]), unname(ref))
+    }, logical(1))
+
+    porter::port_set(port, Enum = value[keep, , drop = FALSE])
+}
+
+defined_type_names <- function(port) {
+    fields <- c("Enum", "Struct", "Union")
+    unique(unlist(lapply(fields, function(field) {
+        value <- port[[field]]$value
+        if (is.null(value) || !nrow(value)) character() else value$name
+    }), use.names = FALSE))
+}
+
+value_type_refs <- function(sig) {
+    # Pointer references are safe as opaque pointers even when the pointed-to
+    # type definition did not survive the version intersection.
+    sig <- gsub("\\*+<[^>]+>", "", sig, perl = TRUE)
+    refs <- regmatches(sig, gregexpr("<[^>]+>", sig, perl = TRUE))[[1L]]
+    if (!length(refs) || identical(refs, character(0))) return(character())
+    unique(sub("^<(.+)>$", "\\1", refs))
+}
+
+intersect_type_field_dependencies <- function(port, field, defined) {
+    value <- port[[field]]$value
+    if (is.null(value) || !nrow(value)) return(port)
+
+    raw <- format(port[[field]], raw = TRUE)
+    keep <- vapply(raw, function(sig) {
+        !length(setdiff(value_type_refs(sig), defined))
+    }, logical(1))
+    args <- list(value[keep, , drop = FALSE])
+    names(args) <- field
+    do.call(porter::port_set, c(list(port), args))
+}
+
+intersect_signature_dependencies <- function(port) {
+    before <- vapply(
+        c("Function", "Variadic", "FuncPtr", "Enum", "Struct", "Union"),
+        field_count, integer(1), port = port
+    )
+
+    repeat {
+        defined <- defined_type_names(port)
+        counts <- vapply(c("Struct", "Union"), field_count, integer(1), port = port)
+        port <- intersect_type_field_dependencies(port, "Struct", defined)
+        port <- intersect_type_field_dependencies(port, "Union", defined)
+        next_counts <- vapply(c("Struct", "Union"), field_count, integer(1), port = port)
+        if (identical(counts, next_counts)) break
+    }
+
+    defined <- defined_type_names(port)
+    for (field in c("Function", "Variadic", "FuncPtr")) {
+        port <- intersect_type_field_dependencies(port, field, defined)
+    }
+
+    after <- vapply(
+        c("Function", "Variadic", "FuncPtr", "Enum", "Struct", "Union"),
+        field_count, integer(1), port = port
+    )
+    if (!identical(before, after)) {
+        message("Dependency closure for by-value named types:")
+        for (field in names(before)) {
+            if (before[[field]] != after[[field]]) {
+                message("  ", field, ": ", before[[field]], " -> ", after[[field]])
+            }
+        }
+    }
+
+    port
+}
+
+intersect_port <- function(port, reference_file) {
+    reference <- read_dynport_values(reference_file)
+    before <- vapply(
+        c("Function", "Variadic", "FuncPtr", "Enum", "Struct", "Union"),
+        field_count, integer(1), port = port
+    )
+
+    for (field in c("Function", "Variadic", "FuncPtr", "Struct", "Union")) {
+        port <- intersect_simple_field(port, reference, field)
+    }
+    port <- intersect_enum_field(port, reference)
+    port <- intersect_signature_dependencies(port)
+
+    after <- vapply(
+        c("Function", "Variadic", "FuncPtr", "Enum", "Struct", "Union"),
+        field_count, integer(1), port = port
+    )
+    message("Intersection against ", reference_file, ":")
+    for (field in names(before)) {
+        message("  ", field, ": ", before[[field]], " -> ", after[[field]])
+    }
+
+    port
+}
+
+generate_port <- function(include, version) {
+    headers <- file.path(include, c("R.h", "Rinternals.h"))
+    missing <- headers[!file.exists(headers)]
+    if (length(missing)) {
+        stop("Cannot find R header(s): ", paste(missing, collapse = ", "), call. = FALSE)
+    }
+
+    header <- tempfile("rdyncall-R-", fileext = ".h")
+    writeLines(c("#include <R.h>", "#include <Rinternals.h>"), header)
+    on.exit(unlink(header), add = TRUE)
+
+    cflags <- paste0("-I", include)
+    porter::port_set(
+        porter::port(header, limit = include, cflags = cflags),
+        Package = "R",
+        Version = version,
+        Library = "R"
+    )
+}
+
+trim_trailing_ws <- function(file) {
+    lines <- readLines(file, warn = FALSE)
+    writeLines(sub("[ \t]+$", "", lines, perl = TRUE), file, useBytes = TRUE)
+}
+
+include <- if (is.null(args$include)) file.path(R.home(), "include") else args$include
+include <- normalizePath(include, mustWork = TRUE)
+version <- if (is.null(args$version)) detect_r_version(include) else args$version
+outfile <- if (is.null(args$output)) {
+    file.path(root, "inst", "dynports", "R.dynport")
+} else {
+    args$output
+}
+outfile <- normalizePath(dirname(outfile), mustWork = TRUE)
+outfile <- file.path(outfile, if (is.null(args$output)) "R.dynport" else basename(args$output))
+
+port <- generate_port(include, version)
+
+if (!is.null(args$snapshot)) {
+    snapshot <- normalizePath(dirname(args$snapshot), mustWork = TRUE)
+    snapshot <- file.path(snapshot, basename(args$snapshot))
+    suppressWarnings(porter::port_write(port, snapshot))
+    trim_trailing_ws(snapshot)
+    message("Wrote unfiltered snapshot ", snapshot)
+}
+
+if (!is.null(args$intersect_with)) {
+    port <- intersect_port(port, normalizePath(args$intersect_with, mustWork = TRUE))
+}
+
+suppressWarnings(porter::port_write(port, outfile))
+trim_trailing_ws(outfile)
+
+report <- porter::port_report(port)
+message("Wrote ", outfile)
+message("Version: ", version)
+if (nrow(report)) {
+    message(
+        "porter recorded ", nrow(report), " diagnostic item",
+        if (nrow(report) == 1L) "" else "s",
+        "; inspect with porter::port_report()."
+    )
+}


### PR DESCRIPTION
## Summary
Add a generated DCF DynPort for the R API so `dynport("R")` can use the new DynPort package path.

## Changes
- Add `inst/dynports/R.dynport` as a curated generated snapshot from R headers.
- Add `tools/dynports/generate-R.R` for regenerating the snapshot with porter.
- List `R` among bundled DCF DynPorts.
- Cover reading, installing, and calling safe fixed R API symbols from the generated DynPort package.

## Out of scope
- Translating the legacy `R.R` dynport.
- Generating callable entries for macros.
