### PR TITLE
fix: resolve runtime libraries by short name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
   pointer handles in addition to short library names.
 - Improve `dynfind()` discovery for libraries installed by common package
   managers, including Homebrew, MacPorts, Linuxbrew and Scoop.
+- Improve `dynfind()` discovery of the current R runtime library and avoid
+  treating same-named directories as direct `dynbind()` library paths.
 - Return nested aggregate fields from `$` as raw-backed `struct` objects so
   they can be reused for field access and aggregate by-value calls.
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.

--- a/R/dynbind.R
+++ b/R/dynbind.R
@@ -201,7 +201,7 @@ dynbind_resolve_libhandle <- function(libnames) {
 }
 
 dynbind_is_library_path <- function(libname) {
-    !is.na(libname) && (grepl("[/\\\\]", libname) || file.exists(libname))
+    !is.na(libname) && (grepl("[/\\\\]", libname) || (file.exists(libname) && !dir.exists(libname)))
 }
 
 dynbind_libnames_label <- function(libnames) {

--- a/R/dynfind.R
+++ b/R/dynfind.R
@@ -33,6 +33,35 @@ dynfind_files <- function(dirs, patterns) {
     }), use.names = FALSE))
 }
 
+dynfind_library_patterns <- function(name) {
+    names <- dynfind_name_variants(name)
+    if (.Platform$OS.type == "windows") {
+        c(paste0(names, ".dll"), paste0("lib", names, ".dll"), paste0(names, "*.dll"), paste0("lib", names, "*.dll"))
+    } else if (Sys.info()[["sysname"]] == "Darwin") {
+        c(paste0("lib", names, ".dylib"), paste0("lib", names, ".*.dylib"))
+    } else {
+        c(paste0("lib", names, ".so"), paste0("lib", names, ".so.*"))
+    }
+}
+
+dynfind_runtime_dirs <- function() {
+    if (.Platform$OS.type == "windows") {
+        return(dynfind_values(c(
+            R.home("bin"),
+            file.path(R.home("bin"), R.version$arch),
+            file.path(R.home("bin"), "x64"),
+            file.path(R.home("bin"), "i386"),
+            R.home("lib")
+        )))
+    }
+
+    dynfind_values(c(R.home("lib"), R.home("bin")))
+}
+
+dynfind_runtime_files <- function(name) {
+    dynfind_files(dynfind_runtime_dirs(), dynfind_library_patterns(name))
+}
+
 dynfind_package_manager_dirs <- function(name) {
     names <- dynfind_name_variants(name)
     if (.Platform$OS.type == "windows") {
@@ -75,20 +104,16 @@ dynfind_package_manager_dirs <- function(name) {
 }
 
 dynfind_package_manager_files <- function(name) {
-    names <- dynfind_name_variants(name)
-    patterns <- if (.Platform$OS.type == "windows") {
-        c(paste0(names, ".dll"), paste0("lib", names, ".dll"), paste0(names, "*.dll"), paste0("lib", names, "*.dll"))
-    } else if (Sys.info()[["sysname"]] == "Darwin") {
-        c(paste0("lib", names, ".dylib"), paste0("lib", names, ".*.dylib"))
-    } else {
-        c(paste0("lib", names, ".so"), paste0("lib", names, ".so.*"))
-    }
-    dynfind_files(dynfind_package_manager_dirs(name), patterns)
+    dynfind_files(dynfind_package_manager_dirs(name), dynfind_library_patterns(name))
 }
 
 dynfind1 <- if (.Platform$OS.type == "windows") {
     function(name, ...) {
         handle <- dynfind_try(c(paste("lib", name, sep = ""), name), ...)
+        if (!is.null(handle)) {
+            return(handle)
+        }
+        handle <- dynfind_try(dynfind_runtime_files(name), ..., existing.only = TRUE)
         if (!is.null(handle)) {
             return(handle)
         }
@@ -101,6 +126,10 @@ dynfind1 <- if (.Platform$OS.type == "windows") {
                 paste(name, ".framework/", name, sep = ""),
                 paste("lib", name, ".dylib", sep = "")
             ), ...)
+            if (!is.null(handle)) {
+                return(handle)
+            }
+            handle <- dynfind_try(dynfind_runtime_files(name), ..., existing.only = TRUE)
             if (!is.null(handle)) {
                 return(handle)
             }
@@ -133,6 +162,10 @@ dynfind1 <- if (.Platform$OS.type == "windows") {
                 paste("lib", name, ".so", sep = ""),
                 paste("lib", name, sep = "")
             ), ...)
+            if (!is.null(handle)) {
+                return(handle)
+            }
+            handle <- dynfind_try(dynfind_runtime_files(name), ..., existing.only = TRUE)
             if (!is.null(handle)) {
                 return(handle)
             }
@@ -200,10 +233,12 @@ dynfind1 <- if (.Platform$OS.type == "windows") {
 #' The vector of `location`s is initialized by the dynamic linker search rules,
 #' including environment variables such as `PATH` on Windows and
 #' `LD_LIBRARY_PATH` on Unix-flavour systems. If the dynamic linker lookup
-#' fails, `dynfind()` also checks common package-manager library locations such
-#' as Homebrew (`HOMEBREW_PREFIX`, `/opt/homebrew`, `/usr/local`), MacPorts
-#' (`MACPORTS_PREFIX`, `/opt/local`), Linuxbrew (`/home/linuxbrew/.linuxbrew`)
-#' and Scoop (`SCOOP`, `SCOOP_GLOBAL`, `ProgramData/scoop`).
+#' fails, `dynfind()` also checks library directories that belong to the
+#' current R runtime, such as `R.home("lib")` and `R.home("bin")`, and common
+#' package-manager library locations such as Homebrew (`HOMEBREW_PREFIX`,
+#' `/opt/homebrew`, `/usr/local`), MacPorts (`MACPORTS_PREFIX`, `/opt/local`),
+#' Linuxbrew (`/home/linuxbrew/.linuxbrew`) and Scoop (`SCOOP`, `SCOOP_GLOBAL`,
+#' `ProgramData/scoop`).
 #' (The set of hardcoded locations might expand and change within the next minor releases).
 #'
 #' The file extension depends on the OS: `.dll` (Windows), `.dylib` (macOS),

--- a/inst/tinytest/test_dynbind.R
+++ b/inst/tinytest/test_dynbind.R
@@ -59,6 +59,22 @@ local({
     expect_dynbind_add(file.path(".", basename(fixture)))
 })
 
+local({
+    rlib <- dynfind("R")
+    if (!is.null(rlib)) {
+        temp_wd <- tempfile("rdyncall-dynbind-short-name-")
+        dir.create(temp_wd)
+        oldwd <- setwd(temp_wd)
+        on.exit(setwd(oldwd), add = TRUE)
+        dir.create("R")
+        env <- new.env()
+        bind <- dynbind("R", "R_ShowMessage(Z)v;", envir = env)
+        expect_equal(class(bind), "dynbind.report")
+        expect_equal(bind$unresolved.symbols, character(0))
+        expect_true(exists("R_ShowMessage", env, inherits = FALSE))
+    }
+})
+
 attr(handle, "dynbind-test") <- "input-handle"
 bind <- expect_dynbind_add(handle)
 expect_equal(attr(bind$libhandle, "dynbind-test"), "input-handle")

--- a/inst/tinytest/test_dynload.R
+++ b/inst/tinytest/test_dynload.R
@@ -19,3 +19,8 @@ if (Sys.info()[["sysname"]] == "Darwin") {
     expect_true(length(libm_symbols) < 1000L)
 }
 expect_null(dynunload(libm))
+
+libr <- dynfind("R")
+expect_true(is.externalptr(libr))
+expect_true(is.externalptr(dynsym(libr, "R_ShowMessage")))
+expect_null(dynunload(libr))

--- a/man/dynfind.Rd
+++ b/man/dynfind.Rd
@@ -69,10 +69,12 @@ useful for all platforms}
 The vector of \code{location}s is initialized by the dynamic linker search rules,
 including environment variables such as \code{PATH} on Windows and
 \code{LD_LIBRARY_PATH} on Unix-flavour systems. If the dynamic linker lookup
-fails, \code{dynfind()} also checks common package-manager library locations such
-as Homebrew (\code{HOMEBREW_PREFIX}, \verb{/opt/homebrew}, \verb{/usr/local}), MacPorts
-(\code{MACPORTS_PREFIX}, \verb{/opt/local}), Linuxbrew (\verb{/home/linuxbrew/.linuxbrew})
-and Scoop (\code{SCOOP}, \code{SCOOP_GLOBAL}, \code{ProgramData/scoop}).
+fails, \code{dynfind()} also checks library directories that belong to the
+current R runtime, such as \code{R.home("lib")} and \code{R.home("bin")}, and common
+package-manager library locations such as Homebrew (\code{HOMEBREW_PREFIX},
+\verb{/opt/homebrew}, \verb{/usr/local}), MacPorts (\code{MACPORTS_PREFIX}, \verb{/opt/local}),
+Linuxbrew (\verb{/home/linuxbrew/.linuxbrew}) and Scoop (\code{SCOOP}, \code{SCOOP_GLOBAL},
+\code{ProgramData/scoop}).
 (The set of hardcoded locations might expand and change within the next minor releases).
 
 The file extension depends on the OS: \code{.dll} (Windows), \code{.dylib} (macOS),


### PR DESCRIPTION
## Summary

Fix short-name resolution for runtime libraries such as `R` when calling `dynfind()` or `dynbind()` from source-tree contexts.

This PR makes `dynfind()` check the current R runtime library directories after normal dynamic linker lookup, and fixes `dynbind()` so an existing directory with the same name as a short library name is not treated as a direct library path.

I checked this in a temporary source copy with install, focused `test_dynbind.R` / `test_dynload.R`, and an examples-focused source check; the source check finished with `Status: OK`.

## Changes

- Add shared library name patterns and current R runtime directories to `dynfind()` search fallback.
- Reuse the same platform library patterns for package-manager discovery.
- Treat bare existing directories as short library names in `dynbind()`, while preserving explicit path handling for strings with path separators.
- Add tinytest coverage for `dynbind("R", ...)` when the working directory contains a same-named `R/` directory.
- Document the runtime-directory lookup and update `NEWS.md`.

## Out of scope

- No demo files are changed in this PR.
- No changes are made to the modern demo branch work.
