### PR TITLE
feat: add S3 print methods

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,11 @@
 
 S3method("$",struct)
 S3method("$<-",struct)
+S3method(print,ctype)
+S3method(print,dynbind.report)
+S3method(print,floatraw)
 S3method(print,struct)
+S3method(print,typeinfo)
 export(as.ctype)
 export(as.externalptr)
 export(as.floatraw)

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
   they can be reused for field access and aggregate by-value calls.
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature.
 - Store aggregate field names in the explicit `typeinfo$fields$name` column.
+- Add dedicated print methods for `typeinfo`, `struct`, `ctype`,
+  `dynbind.report` and `floatraw` objects.
 - Add `struct` and `union` bitfield layout, access, DynPort parsing, and by-value aggregate support.
 - Add the `rdyncall.callvm.size` option to configure CallVM argument stack size at package load.
 - Add by-value aggregate argument and return support to `dyncall()` for registered `struct` and `union` types on supported dyncall backends, including ARM64 aggregate ABI handling.

--- a/R/dynbind.R
+++ b/R/dynbind.R
@@ -82,6 +82,10 @@
 #'        functions (`FALSE`, default) or to function pointer variables
 #'        (`TRUE` rarely needed).
 #'
+#' @param x S3 `dynbind.report` object to print.
+#'
+#' @param ... additional arguments to be passed to [base::print()] methods.
+#'
 #' @return
 #' The function returns a list with two fields:
 #'
@@ -172,6 +176,23 @@ dynbind <- function(libnames, signature, envir = parent.frame(), callmode = "def
         list(libhandle = libh, unresolved.symbols = syms.failed),
         class = "dynbind.report"
     )
+}
+
+#' @rdname dynbind
+#' @export
+print.dynbind.report <- function(x, ...) {
+    path <- attr(x$libhandle, "path")
+    if (length(path) == 0L || all(is.na(path))) path <- "<unknown>"
+    unresolved <- x$unresolved.symbols
+
+    cat("dynbind report\n")
+    cat("  library: ", path[[1L]], "\n", sep = "")
+    cat("  unresolved symbols: ", length(unresolved), "\n", sep = "")
+    if (length(unresolved)) {
+        cat("    ", paste(unresolved, collapse = "\n    "), "\n", sep = "")
+    }
+
+    invisible(x)
 }
 
 dynbind_resolve_libhandle <- function(libnames) {

--- a/R/struct.R
+++ b/R/struct.R
@@ -58,6 +58,10 @@
 #'        bitfield layout information that specifies aggregate struct and union
 #'        types.
 #'
+#' @param x S3 `typeinfo` object to print.
+#'
+#' @param ... additional arguments to be passed to [base::print()] methods.
+#'
 #' @return
 #' List object tagged as S3 class `typeinfo` with the following named entries
 #' \item{type}{Type name.}
@@ -92,6 +96,43 @@ typeinfo <- function(name, type = c("base", "pointer", "struct", "union"),
         ),
         class = "typeinfo"
     )
+}
+
+#' @rdname typeinfo
+#' @export
+print.typeinfo <- function(x, ...) {
+    typeinfo_value <- function(value) {
+        if (length(value) == 0L || all(is.na(value))) "<unknown>" else as.character(value)
+    }
+
+    cat(x$type, " typeinfo ", x$name, "\n", sep = "")
+    cat("  size: ", typeinfo_value(x$size), "\n", sep = "")
+    cat("  align: ", typeinfo_value(x$align), "\n", sep = "")
+    if (!all(is.na(x$signature))) {
+        cat("  signature: ", x$signature, "\n", sep = "")
+    }
+    if (identical(x$type, "pointer") && !all(is.na(x$basetype))) {
+        cat("  basetype: ", x$basetype, "\n", sep = "")
+    }
+
+    if (is.data.frame(x$fields)) {
+        cat("  fields:\n")
+        if (!nrow(x$fields)) {
+            cat("    <none>\n")
+        } else {
+            fields <- x$fields
+            fields$type <- as.character(fields$type)
+            base_cols <- c("name", "type", "offset", "array_len")
+            bit_cols <- c("bit_offset", "bit_width", "storage_offset", "storage_size")
+            cols <- base_cols[base_cols %in% names(fields)]
+            if ("bit_width" %in% names(fields) && any(!is.na(fields$bit_width))) {
+                cols <- c(cols, bit_cols[bit_cols %in% names(fields)])
+            }
+            print(fields[cols], row.names = FALSE)
+        }
+    }
+
+    invisible(x)
 }
 
 is.typeinfo <- function(x) {
@@ -789,19 +830,28 @@ cunion <- function(sigs, envir = parent.frame()) {
 #' @rdname struct
 #' @export
 as.ctype <- function(x, type) {
-    # TODO: check
-    if (is.typeinfo(x)) struct_name <- type$name
+    caller <- parent.frame()
+    if (is.character(type)) {
+        type <- get_typeinfo(type, caller)
+    } else if (!is.typeinfo(type)) {
+        stop("type is not of class typeinfo and no character string")
+    }
+    if (!type$type %in% c("struct", "union")) stop("type must be C struct or union.")
     attr(x, "ctype") <- type
-    class(x) <- "ctype"
+    attr(x, "struct") <- type$name
+    attr(x, "typeinfo") <- type
+    attr(x, "typeinfo_env") <- caller
+    class(x) <- c("ctype", "struct")
     return(x)
 }
 
 #' @rdname struct
 #' @export
 cdata <- function(type) {
+    caller <- parent.frame()
     if (is.character(type)) {
         name <- type
-        type <- get_typeinfo(type)
+        type <- get_typeinfo(type, caller)
     } else if (is.typeinfo(type)) {
         name <- type$name
     } else {
@@ -812,12 +862,13 @@ cdata <- function(type) {
     class(x) <- "struct"
     attr(x, "struct") <- type$name
     attr(x, "typeinfo") <- type
+    attr(x, "typeinfo_env") <- caller
     return(x)
 }
 
-as_aggregate_field <- function(x, type) {
+as_aggregate_field <- function(x, type, envir = parent.frame()) {
     if (is.character(type)) {
-        type <- get_typeinfo(type)
+        type <- get_typeinfo(type, envir)
     } else if (!is.typeinfo(type)) {
         stop("type is not of class typeinfo and no character string")
     }
@@ -825,6 +876,7 @@ as_aggregate_field <- function(x, type) {
     class(x) <- "struct"
     attr(x, "struct") <- type$name
     attr(x, "typeinfo") <- type
+    attr(x, "typeinfo_env") <- envir
     x
 }
 
@@ -835,7 +887,9 @@ struct_typeinfo <- function(x, envir = parent.frame()) {
         return(info)
     }
 
-    info <- get_typeinfo(struct_name, envir = envir)
+    lookup_env <- attr(x, "typeinfo_env")
+    if (!is.environment(lookup_env)) lookup_env <- envir
+    info <- get_typeinfo(struct_name, envir = lookup_env)
     if (!is.null(info)) return(info)
 
     stop("unknown struct type '", struct_name, "'")
@@ -880,14 +934,17 @@ pack_array_field <- function(x, offset, field_type_info, array_len, value) {
     invisible(NULL)
 }
 
-unpack_aggregate_array_field <- function(x, offset, field_type_name, field_type_info, array_len) {
+unpack_aggregate_array_field <- function(x, offset, field_type_name, field_type_info,
+                                         array_len, envir = parent.frame()) {
     unpack_one <- function(i) {
         element_offset <- offset + (i - 1L) * field_type_info$size
         if (is.raw(x)) {
             size <- field_type_info$size
-            as_aggregate_field(x[(element_offset + 1):(element_offset + size)], field_type_info)
+            as_aggregate_field(x[(element_offset + 1):(element_offset + size)],
+                field_type_info, envir = envir
+            )
         } else if (is.externalptr(x)) {
-            as_aggregate_field(offset_ptr(x, element_offset), field_type_info)
+            as_aggregate_field(offset_ptr(x, element_offset), field_type_info, envir = envir)
         }
     }
 
@@ -918,6 +975,8 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
 `$.struct` <- unpack.struct <- function(x, index) {
     caller <- parent.frame()
     struct_info <- struct_typeinfo(x, caller)
+    lookup_env <- attr(x, "typeinfo_env")
+    if (!is.environment(lookup_env)) lookup_env <- caller
     field_info <- struct_info$fields
     field_index <- match(index, field_info$name)
     if (is.na(field_index)) stop("unknown field index '", index, "'")
@@ -931,12 +990,14 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
     }
     offset <- field_info[field_index, "offset"]
     field_type_name <- as.character(field_info[[field_index, "type"]])
-    field_type_info <- get_typeinfo(field_type_name, caller)
+    field_type_info <- get_typeinfo(field_type_name, lookup_env)
     array_len <- field_array_len(field_info, field_index)
     if (field_type_info$type %in% c("base", "pointer")) {
         unpack_array_field(x, offset, field_type_info, array_len)
     } else if (!is.null(field_type_info$fields)) {
-        unpack_aggregate_array_field(x, offset, field_type_name, field_type_info, array_len)
+        unpack_aggregate_array_field(x, offset, field_type_name, field_type_info,
+            array_len, envir = lookup_env
+        )
     } else {
         stop("invalid field type '", field_type_name, "' at field '", index)
     }
@@ -947,6 +1008,8 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
 `$<-.struct` <- pack.struct <- function(x, index, value) {
     caller <- parent.frame()
     struct_info <- struct_typeinfo(x, caller)
+    lookup_env <- attr(x, "typeinfo_env")
+    if (!is.environment(lookup_env)) lookup_env <- caller
     field_info <- struct_info$fields
     field_index <- match(index, field_info$name)
     if (is.na(field_index)) stop("unknown field index '", index, "'")
@@ -961,7 +1024,7 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
     }
     offset <- field_info[field_index, "offset"]
     field_type_name <- as.character(field_info[field_index, "type"])
-    field_type_info <- get_typeinfo(field_type_name, caller)
+    field_type_info <- get_typeinfo(field_type_name, lookup_env)
     array_len <- field_array_len(field_info, field_index)
     if (field_type_info$type %in% c("base", "pointer")) {
         pack_array_field(x, offset, field_type_info, array_len, value)
@@ -977,18 +1040,37 @@ pack_aggregate_array_field <- function(x, offset, field_type_info, array_len, va
 #' @rdname struct
 #' @export
 print.struct <- function(x, indent = 0, ...) {
+    print_struct_value <- function(value, indent) {
+        if (typeof(value) == "externalptr") {
+            cat(if (is.nullptr(value)) "NULL" else "ptr", "\n")
+        } else if (inherits(value, "struct")) {
+            print.struct(value, indent = indent)
+        } else if (is.list(value) && length(value) && all(vapply(value, inherits, logical(1L), "struct"))) {
+            cat("[\n")
+            for (i in seq_along(value)) {
+                cat(rep("  ", indent + 1L), "[[", i, "]]: ", sep = "")
+                print.struct(value[[i]], indent = indent + 1L)
+            }
+            cat(rep("  ", indent), "]\n", sep = "")
+        } else if (length(value) == 0L) {
+            cat("<empty>\n")
+        } else {
+            cat(paste(value, collapse = " "), "\n")
+        }
+    }
+
     struct_name <- attr(x, "struct")
     struct_info <- struct_typeinfo(x, parent.frame())
     field_info <- struct_info$fields
     field_names <- field_info$name
     field_names <- field_names[nzchar(field_names)]
 
-    cat("struct ", struct_name, " ")
+    cat(struct_info$type, " ", struct_name, " ", sep = "")
     if (typeof(x) == "externalptr") {
         cat("*")
         if (is.nullptr(x)) {
             cat("=NULL\n")
-            return()
+            return(invisible(x))
         }
     }
     cat("{\n")
@@ -997,12 +1079,15 @@ print.struct <- function(x, indent = 0, ...) {
     {
         cat(rep("  ", indent + 1), field_names[[i]], ":")
         val <- unpack.struct(x, field_names[[i]])
-        if (typeof(val) == "externalptr") val <- "ptr" # .extptr2str(val)
-        if (inherits(val, "struct")) {
-            print.struct(val, indent = indent + 1)
-        } else {
-            cat(val, "\n")
-        }
+        print_struct_value(val, indent = indent + 1L)
     }
     cat(rep("  ", indent), "}\n")
+    invisible(x)
+}
+
+#' @rdname struct
+#' @export
+print.ctype <- function(x, ...) {
+    print.struct(x, ...)
+    invisible(x)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,6 +52,8 @@
 #' @param n integer specifying the number of single-precision C `float` values
 #'        to allocate.
 #'
+#' @param ... additional arguments to be passed to [base::print()] methods.
+#'
 #' @examples
 #' is.nullptr(NULL)
 #'
@@ -102,6 +104,25 @@ floatraw <- function(n) {
     x <- raw(n * 4)
     class(x) <- "floatraw"
     x
+}
+
+#' @rdname utils
+#' @export
+print.floatraw <- function(x, ...) {
+    nbytes <- length(x)
+    if (nbytes %% 4L != 0L) {
+        cat("floatraw bytes[", nbytes, "]: ", paste(format(unclass(x)), collapse = " "), "\n", sep = "")
+        return(invisible(x))
+    }
+
+    n <- nbytes / 4L
+    cat("floatraw[", n, "]", sep = "")
+    if (n) {
+        cat(": ", paste(format(floatraw2numeric(x)), collapse = " "), sep = "")
+    }
+    cat("\n")
+
+    invisible(x)
 }
 #' @rdname utils
 #' @export

--- a/inst/tinytest/test_dynbind.R
+++ b/inst/tinytest/test_dynbind.R
@@ -7,6 +7,18 @@ expect_equal(
     "dynbind.report"
 )
 expect_true(exists("c_qsort", env, inherits = FALSE))
+bind_print <- capture.output(expect_identical(print(bind), bind))
+expect_true(any(grepl("dynbind report", bind_print, fixed = TRUE)))
+expect_true(any(grepl("unresolved symbols: 0", bind_print, fixed = TRUE)))
+
+missing_bind <- dynbind(
+    c("msvcrt", "c", "c.so.6"),
+    "rdyncall_missing_symbol_for_print_probe(i)i;",
+    envir = new.env()
+)
+missing_bind_print <- capture.output(expect_identical(print(missing_bind), missing_bind))
+expect_true(any(grepl("unresolved symbols: 1", missing_bind_print, fixed = TRUE)))
+expect_true(any(grepl("rdyncall_missing_symbol_for_print_probe", missing_bind_print, fixed = TRUE)))
 
 build_dynbind_fixture <- function() {
     src <- system.file("tinytest", "dynbind.c", package = "rdyncall", mustWork = TRUE)

--- a/inst/tinytest/test_dynstruct.R
+++ b/inst/tinytest/test_dynstruct.R
@@ -23,6 +23,83 @@ expect_equal(
 )
 expect_error(rdyncall:::get_typeinfo(1))
 
+typeinfo_base_print <- capture.output(print(rdyncall:::get_typeinfo("p")))
+expect_true(any(grepl("base typeinfo p", typeinfo_base_print, fixed = TRUE)))
+expect_true(any(grepl("signature: p", typeinfo_base_print, fixed = TRUE)))
+
+typeinfo_pointer_print <- capture.output(print(rdyncall:::get_typeinfo("*i")))
+expect_true(any(grepl("pointer typeinfo *i", typeinfo_pointer_print, fixed = TRUE)))
+expect_true(any(grepl("basetype: i", typeinfo_pointer_print, fixed = TRUE)))
+
+local({
+    env <- new.env()
+    cstruct("PrintRect{ssSS}x y w h;", env)
+    rect_type_print <- capture.output(print(env$PrintRect))
+    expect_true(any(grepl("struct typeinfo PrintRect", rect_type_print, fixed = TRUE)))
+    expect_true(any(grepl("signature: ssSS", rect_type_print, fixed = TRUE)))
+    expect_true(any(grepl("array_len", rect_type_print, fixed = TRUE)))
+
+    rect <- cdata(env$PrintRect)
+    rect$x <- 1L
+    rect$y <- 2L
+    rect$w <- 3L
+    rect$h <- 4L
+    rect_print <- capture.output(expect_identical(print(rect), rect))
+    expect_true(any(grepl("struct PrintRect", rect_print, fixed = TRUE)))
+    expect_true(any(grepl("x :1", rect_print, fixed = TRUE)))
+
+    cunion("PrintUnion|iC}i c;", env)
+    union <- cdata(env$PrintUnion)
+    union$i <- 42L
+    union_print <- capture.output(expect_identical(print(union), union))
+    expect_true(any(grepl("union PrintUnion", union_print, fixed = TRUE)))
+
+    cstruct("PrintArray{C[3]}bytes;", env)
+    array <- cdata(env$PrintArray)
+    array$bytes <- 1:3
+    array_print <- capture.output(print(array))
+    expect_true(any(grepl("bytes :1 2 3", array_print, fixed = TRUE)))
+
+    cstruct("PrintBits{IIII}a:1 b:3 :4 c:8;", env)
+    bits_type_print <- capture.output(print(env$PrintBits))
+    expect_true(any(grepl("bit_width", bits_type_print, fixed = TRUE)))
+    bits <- cdata(env$PrintBits)
+    bits$a <- 1L
+    bits$b <- 5L
+    bits$c <- 171L
+    bits_print <- capture.output(print(bits))
+    expect_true(any(grepl("a :1", bits_print, fixed = TRUE)))
+    expect_true(any(grepl("b :5", bits_print, fixed = TRUE)))
+
+    cstruct("PrintEmpty{};", env)
+    empty_print <- capture.output(print(env$PrintEmpty))
+    expect_true(any(grepl("<none>", empty_print, fixed = TRUE)))
+
+    ctype <- as.ctype(raw(env$PrintRect$size), env$PrintRect)
+    ctype$x <- 7L
+    expect_equal(ctype$x, 7L)
+    expect_true(inherits(ctype, "ctype"))
+    expect_true(inherits(ctype, "struct"))
+    ctype_print <- capture.output(expect_identical(print(ctype), ctype))
+    expect_true(any(grepl("struct PrintRect", ctype_print, fixed = TRUE)))
+    expect_true(any(grepl("x :7", ctype_print, fixed = TRUE)))
+})
+
+cstruct("PrintVec2{ff}x y;")
+cstruct("PrintHolder{<PrintVec2>[2]}xy;")
+holder <- cdata(PrintHolder)
+vec_a <- cdata(PrintVec2)
+vec_a$x <- 1
+vec_a$y <- 2
+vec_b <- cdata(PrintVec2)
+vec_b$x <- 3
+vec_b$y <- 4
+holder$xy <- list(vec_a, vec_b)
+holder_print <- capture.output(print(holder))
+expect_true(any(grepl("xy :[", holder_print, fixed = TRUE)))
+expect_true(any(grepl("[[1]]: struct PrintVec2", holder_print, fixed = TRUE)))
+expect_true(any(grepl("[[2]]: struct PrintVec2", holder_print, fixed = TRUE)))
+
 expect_equal(rdyncall:::align(4, 8), 8L)
 
 local({

--- a/inst/tinytest/test_utils_float.R
+++ b/inst/tinytest/test_utils_float.R
@@ -1,2 +1,20 @@
 expect_equal(class(as.floatraw(1)), "floatraw")
 expect_equal(floatraw2numeric(as.floatraw(1:2)), 1:2)
+
+empty <- floatraw(0)
+empty_floatraw_print <- capture.output(empty_floatraw_return <- print(empty))
+expect_equal(empty_floatraw_print, "floatraw[0]")
+expect_identical(empty_floatraw_return, empty)
+
+floats <- as.floatraw(c(1, 2.5))
+floats_print <- capture.output(floats_return <- print(floats))
+expect_true(any(grepl("floatraw[2]:", floats_print, fixed = TRUE)))
+expect_true(any(grepl("1.0", floats_print, fixed = TRUE)))
+expect_true(any(grepl("2.5", floats_print, fixed = TRUE)))
+expect_identical(floats_return, floats)
+
+odd <- raw(3)
+class(odd) <- "floatraw"
+odd_print <- capture.output(odd_return <- print(odd))
+expect_equal(odd_print, "floatraw bytes[3]: 00 00 00")
+expect_identical(odd_return, odd)

--- a/man/dynbind.Rd
+++ b/man/dynbind.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/dynbind.R
 \name{dynbind}
 \alias{dynbind}
+\alias{print.dynbind.report}
 \title{Binding C library functions via thin call wrappers}
 \usage{
 dynbind(
@@ -13,6 +14,8 @@ dynbind(
   replace = NULL,
   funcptr = FALSE
 )
+
+\method{print}{dynbind.report}(x, ...)
 }
 \arguments{
 \item{libnames}{character vector or external pointer handle specifying the
@@ -39,6 +42,10 @@ part of symbolic names.}
 \item{funcptr}{logical, that indicates whether foreign objects refer to
 functions (\code{FALSE}, default) or to function pointer variables
 (\code{TRUE} rarely needed).}
+
+\item{x}{S3 \code{dynbind.report} object to print.}
+
+\item{...}{additional arguments to be passed to \code{\link[base:print]{base::print()}} methods.}
 }
 \value{
 The function returns a list with two fields:

--- a/man/struct.Rd
+++ b/man/struct.Rd
@@ -8,6 +8,7 @@
 \alias{$.struct}
 \alias{$<-.struct}
 \alias{print.struct}
+\alias{print.ctype}
 \title{Allocation and handling of foreign C aggregate data types}
 \usage{
 cstruct(sigs, envir = parent.frame())
@@ -23,6 +24,8 @@ cdata(type)
 \method{$}{struct}(x, index) <- value
 
 \method{print}{struct}(x, indent = 0, ...)
+
+\method{print}{ctype}(x, ...)
 }
 \arguments{
 \item{sigs}{character string that specifies several C struct/union type

--- a/man/typeinfo.Rd
+++ b/man/typeinfo.Rd
@@ -3,6 +3,7 @@
 \name{typeinfo}
 \alias{typeinfo}
 \alias{type-information}
+\alias{print.typeinfo}
 \alias{get_typeinfo}
 \title{S3 class for run-time type information of foreign C data types}
 \usage{
@@ -15,6 +16,8 @@ typeinfo(
   fields = NA,
   signature = NA
 )
+
+\method{print}{typeinfo}(x, ...)
 
 get_typeinfo(name, envir = parent.frame())
 }
@@ -35,6 +38,10 @@ types.}
 
 \item{signature}{character string specifying the struct/union type
 \link[=type-signature]{signature}.}
+
+\item{x}{S3 \code{typeinfo} object to print.}
+
+\item{...}{additional arguments to be passed to \code{\link[base:print]{base::print()}} methods.}
 
 \item{envir}{the environment to look for type object.}
 }

--- a/man/utils.Rd
+++ b/man/utils.Rd
@@ -8,6 +8,7 @@
 \alias{as.floatraw}
 \alias{floatraw2numeric}
 \alias{floatraw}
+\alias{print.floatraw}
 \alias{ptr2str}
 \alias{strarrayptr}
 \alias{strptr}
@@ -27,6 +28,8 @@ floatraw2numeric(x)
 
 floatraw(n)
 
+\method{print}{floatraw}(x, ...)
+
 ptr2str(x)
 
 strarrayptr(x)
@@ -40,6 +43,8 @@ strptr(x)
 
 \item{n}{integer specifying the number of single-precision C \code{float} values
 to allocate.}
+
+\item{...}{additional arguments to be passed to \code{\link[base:print]{base::print()}} methods.}
 }
 \value{
 A logical value is returned by \code{is.nullptr()} and \code{is.externalptr()}.


### PR DESCRIPTION
## Summary

- Add dedicated S3 print methods for `typeinfo`, `ctype`, `dynbind.report`, and `floatraw`.
- Make `as.ctype()` produce a real typed `struct` view so field access and printing share the existing aggregate path.
- Confirmed with focused tinytest coverage and full `R CMD check` on a temporary source tarball, which finished with `Status: OK`.

## Changes

- Register the new print methods through roxygen-generated `NAMESPACE` output and update generated Rd pages.
- Improve `print.struct()` so vectors, nested aggregate fields, fixed aggregate arrays, and pointer-like values print without falling back to raw list output.
- Preserve local type lookup environments for `cdata()`, `as.ctype()`, and nested aggregate views.
- Add tinytest coverage for typeinfo summaries, struct/union printing, `ctype` views, `dynbind.report`, and `floatraw`.

## Out of scope

- No changes to the C/dyncall layer.
- No demo behavior changes.
