### PR TITLE
feat: support aggregate callbacks by value

### DIFF
--- a/.github/workflows/arm64-aggregate.yaml
+++ b/.github/workflows/arm64-aggregate.yaml
@@ -32,25 +32,39 @@ jobs:
         if: runner.os == 'Windows'
         run: cmake -S src/dyncall -B build/dyncall -A ARM64 -DLANG_CXX=OFF
 
-      - name: Build dyncall plain aggregate test
+      - name: Build dyncall native aggregate tests
         if: runner.os != 'Windows'
-        run: cmake --build build/dyncall --target plain --config Release --parallel
+        run: >
+          cmake --build build/dyncall --config Release --parallel
+          --target plain call_suite_aggrs callback_plain callback_suite_aggrs
 
-      - name: Build dyncall plain aggregate test (Windows ARM64)
+      - name: Build dyncall native aggregate tests (Windows ARM64)
         if: runner.os == 'Windows'
         run: |
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $msbuild = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
           if (-not $msbuild) { throw "MSBuild not found" }
-          & $msbuild .\build\dyncall\test\plain\plain.vcxproj /p:Configuration=Release /p:Platform=ARM64 /m
+          $targets = @("plain", "call_suite_aggrs", "callback_plain", "callback_suite_aggrs")
+          foreach ($target in $targets) {
+            & $msbuild ".\build\dyncall\test\$target\$target.vcxproj" /p:Configuration=Release /p:Platform=ARM64 /m
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
-      - name: Run dyncall plain aggregate test
+      - name: Run dyncall native aggregate tests
         if: runner.os != 'Windows'
-        run: ./build/dyncall/test/plain/plain
+        run: |
+          ./build/dyncall/test/plain/plain
+          ./build/dyncall/test/call_suite_aggrs/call_suite_aggrs
+          ./build/dyncall/test/callback_plain/callback_plain
+          ./build/dyncall/test/callback_suite_aggrs/callback_suite_aggrs
 
-      - name: Run dyncall plain aggregate test (Windows ARM64)
+      - name: Run dyncall native aggregate tests (Windows ARM64)
         if: runner.os == 'Windows'
-        run: .\\build\\dyncall\\test\\plain\\Release\\plain.exe
+        run: |
+          .\build\dyncall\test\plain\Release\plain.exe
+          .\build\dyncall\test\call_suite_aggrs\Release\call_suite_aggrs.exe
+          .\build\dyncall\test\callback_plain\Release\callback_plain.exe
+          .\build\dyncall\test\callback_suite_aggrs\Release\callback_suite_aggrs.exe
 
   r-focused:
     name: R focused aggregate (${{ matrix.os }})

--- a/R/callback.R
+++ b/R/callback.R
@@ -32,7 +32,18 @@
 #' Finally, the handler evaluates the R call expression within the environment
 #' given by `envir`. On return, the R return value of `fun` is coerced to the C
 #' value, according to the return type signature specified in `signature` .
-#' Aggregate by-value callback arguments and returns are currently unsupported.
+#'
+#' Aggregate by-value callback arguments and returns use the same `<Type>`
+#' signature syntax as [dyncall()]. An aggregate argument is passed to the R
+#' callback as a raw-backed `cdata` object with `struct` and `typeinfo`
+#' attributes. An aggregate return value must be a raw-backed object for the
+#' same aggregate type and size. Type or storage mismatches disable the callback
+#' and emit a warning.
+#'
+#' Aggregate callbacks are supported on the implemented 64-bit x86 and ARM64
+#' dyncallback backends. On unsupported backends, creating a callback whose
+#' signature contains `<Type>` fails early.
+#'
 #' If an error occurs during the evaluation, the callback will be disabled for
 #' further invocations. (This behaviour might change in the future.)
 #'
@@ -87,12 +98,79 @@
 #' @rdname callback
 #' @export
 ccallback <- function(signature, fun, envir = new.env()) {
+    caller <- parent.frame()
     stopifnot(is.character(signature))
     stopifnot(is.function(fun))
     stopifnot(is.environment(envir))
-    if (grepl("<", signature, fixed = TRUE)) {
-        stop("aggregate callback signatures are not supported", call. = FALSE)
+
+    info <- callback_signature_info(signature, caller)
+    .Call("C_callback", info$signature, info$aggregates, info$typeinfos, fun, envir, PACKAGE = "rdyncall")
+}
+
+callback_signature_info <- function(signature, envir = parent.frame()) {
+    if (!is.character(signature) || length(signature) != 1L || is.na(signature)) {
+        stop("'signature' must be a single character string", call. = FALSE)
     }
 
-    .Call("C_callback", signature, fun, envir, PACKAGE = "rdyncall")
+    n <- nchar(signature)
+    i <- 1L
+    out <- character()
+    aggregates <- list()
+    typeinfos <- list()
+
+    append_aggregate <- function(name) {
+        info <- get_typeinfo(name, envir = envir)
+        if (is.null(info)) {
+            stop("unknown aggregate type '", name, "'", call. = FALSE)
+        }
+        aggregates[[length(aggregates) + 1L]] <<- dyncall_aggregate_layout(name, envir = envir)
+        typeinfos[[length(typeinfos) + 1L]] <<- info
+    }
+
+    append_pointer <- function() {
+        out[[length(out) + 1L]] <<- "p"
+    }
+
+    if (n >= 2L && substr(signature, 1L, 1L) == "_") {
+        out <- c(substr(signature, 1L, 1L), substr(signature, 2L, 2L))
+        i <- 3L
+    }
+
+    while (i <= n) {
+        ch <- substr(signature, i, i)
+
+        if (ch == "A") {
+            stop("signature type 'A' is reserved for internal aggregate callbacks; use '<Type>'", call. = FALSE)
+        }
+
+        if (ch == "*") {
+            while (i <= n && substr(signature, i, i) == "*") {
+                i <- i + 1L
+            }
+            if (i > n) {
+                stop("invalid pointer signature: missing pointed-to type", call. = FALSE)
+            }
+            if (substr(signature, i, i) == "<") {
+                type <- dyncall_aggregate_signature_type(signature, i)
+                i <- type$next_index + 1L
+            } else {
+                i <- i + 1L
+            }
+            append_pointer()
+            next
+        }
+
+        if (ch == "<") {
+            type <- dyncall_aggregate_signature_type(signature, i)
+            append_aggregate(type$name)
+            out[[length(out) + 1L]] <- "A"
+            i <- type$next_index + 1L
+            next
+        }
+
+        out[[length(out) + 1L]] <- ch
+        i <- i + 1L
+    }
+
+    list(signature = paste0(out, collapse = ""), aggregates = aggregates, typeinfos = typeinfos)
 }

--- a/R/rdyncall-package.R
+++ b/R/rdyncall-package.R
@@ -23,7 +23,7 @@
 #' ordinary struct and union fields, fixed-size array fields, integer bitfields,
 #' packed layouts, manual alignment directives and by-value aggregate calls on
 #' supported DynCall backends. Aggregate by-value callback arguments and returns
-#' are currently unsupported.
+#' are supported on implemented 64-bit x86 and ARM64 dyncallback backends.
 #'
 #' R functions can be wrapped as C function pointers with [ccallback()]. Keep an
 #' R reference to callback objects for as long as foreign code may call them.

--- a/inst/tinytest/aggregate_by_value.c
+++ b/inst/tinytest/aggregate_by_value.c
@@ -481,3 +481,34 @@ RDYNCALL_TEST_EXPORT rdyncall_test_bits rdyncall_test_make_bits(unsigned int a, 
   out.c = c;
   return out;
 }
+
+typedef int (*rdyncall_test_color_callback)(rdyncall_test_color);
+typedef double (*rdyncall_test_vec2_mix_callback)(int, rdyncall_test_vec2, double);
+typedef rdyncall_test_color (*rdyncall_test_make_color_callback)(unsigned char, unsigned char, unsigned char, unsigned char);
+typedef rdyncall_test_vec2 (*rdyncall_test_make_vec2_callback)(float, float);
+typedef rdyncall_test_more_than_regs (*rdyncall_test_make_more_than_regs_callback)(double);
+
+RDYNCALL_TEST_EXPORT int rdyncall_test_call_color_callback(rdyncall_test_color_callback cb, rdyncall_test_color x)
+{
+  return cb(x);
+}
+
+RDYNCALL_TEST_EXPORT double rdyncall_test_call_vec2_mix_callback(rdyncall_test_vec2_mix_callback cb, int i, rdyncall_test_vec2 x, double y)
+{
+  return cb(i, x, y);
+}
+
+RDYNCALL_TEST_EXPORT rdyncall_test_color rdyncall_test_call_make_color_callback(rdyncall_test_make_color_callback cb, unsigned char r, unsigned char g, unsigned char b, unsigned char a)
+{
+  return cb(r, g, b, a);
+}
+
+RDYNCALL_TEST_EXPORT rdyncall_test_vec2 rdyncall_test_call_make_vec2_callback(rdyncall_test_make_vec2_callback cb, float x, float y)
+{
+  return cb(x, y);
+}
+
+RDYNCALL_TEST_EXPORT rdyncall_test_more_than_regs rdyncall_test_call_make_more_than_regs_callback(rdyncall_test_make_more_than_regs_callback cb, double base)
+{
+  return cb(base);
+}

--- a/inst/tinytest/test_dyncall.R
+++ b/inst/tinytest/test_dyncall.R
@@ -445,9 +445,64 @@ expect_equal(bits_ret$a, 1)
 expect_equal(bits_ret$b, 2)
 expect_equal(bits_ret$c, 3)
 
+# C can call R callbacks that take and return aggregate values by value.
+call_color_callback <- dynsym(aggregate_fixture, "rdyncall_test_call_color_callback")
+color_callback <- ccallback("<Color>)i", function(x) {
+    x$r + 10L * x$g + 100L * x$b + 1000L * x$a
+})
+expect_equal(dyncall(call_color_callback, "p<Color>)i", color_callback, color), 4321L)
+
+call_vec2_mix_callback <- dynsym(aggregate_fixture, "rdyncall_test_call_vec2_mix_callback")
+vec2_mix_callback <- ccallback("i<Vec2>d)d", function(i, x, y) {
+    i + x$x + x$y + y
+})
+expect_equal(dyncall(call_vec2_mix_callback, "pi<Vec2>d)d", vec2_mix_callback, 10L, vec2, 3.25), 17)
+
+call_make_color_callback <- dynsym(aggregate_fixture, "rdyncall_test_call_make_color_callback")
+make_color_callback <- ccallback("CCCC)<Color>", function(r, g, b, a) {
+    out <- cdata(Color)
+    out$r <- r
+    out$g <- g
+    out$b <- b
+    out$a <- a
+    out
+})
+callback_color <- dyncall(call_make_color_callback, "pCCCC)<Color>", make_color_callback, 9L, 10L, 11L, 12L)
+expect_struct_raw(callback_color, "Color")
+expect_equal(callback_color$r, 9)
+expect_equal(callback_color$g, 10)
+expect_equal(callback_color$b, 11)
+expect_equal(callback_color$a, 12)
+
+call_make_vec2_callback <- dynsym(aggregate_fixture, "rdyncall_test_call_make_vec2_callback")
+make_vec2_callback <- ccallback("ff)<Vec2>", function(x, y) {
+    out <- cdata(Vec2)
+    out$x <- x + 1
+    out$y <- y + 2
+    out
+})
+callback_vec2 <- dyncall(call_make_vec2_callback, "pff)<Vec2>", make_vec2_callback, 1.5, 2.5)
+expect_struct_raw(callback_vec2, "Vec2")
+expect_equal(callback_vec2$x, 2.5)
+expect_equal(callback_vec2$y, 4.5)
+
+call_make_more_callback <- dynsym(aggregate_fixture, "rdyncall_test_call_make_more_than_regs_callback")
+make_more_callback <- ccallback("d)<MoreThanRegs>", function(base) {
+    out <- cdata(MoreThanRegs)
+    for (field in names(more_values)) {
+        pack(out, field_offset(MoreThanRegs, field), "d", base + more_values[[field]])
+    }
+    out
+})
+callback_more <- dyncall(call_make_more_callback, "pd)<MoreThanRegs>", make_more_callback, 20)
+expect_struct_raw(callback_more, "MoreThanRegs")
+for (field in names(more_values)) {
+    expect_equal(unpack(callback_more, field_offset(MoreThanRegs, field), "d"), 20 + more_values[[field]])
+}
+
 # Aggregate errors remain explicit.
 wrong_color <- color
 attr(wrong_color, "struct") <- "Vec2"
 expect_error(dyncall(color_sum, "<Color>)i", wrong_color), "incompatible aggregate types")
 expect_error(dyncall(color_sum, "<Missing>)i", color), "unknown aggregate type")
-expect_error(ccallback("<Color>)i", function(x) 0L), "aggregate|signature|Unknown|unsupported")
+expect_error(ccallback("<Missing>)i", function(x) 0L), "unknown aggregate type")

--- a/man/callback.Rd
+++ b/man/callback.Rd
@@ -42,7 +42,18 @@ specified. See \code{\link[=dyncall]{dyncall()}} for details on the format.
 Finally, the handler evaluates the R call expression within the environment
 given by \code{envir}. On return, the R return value of \code{fun} is coerced to the C
 value, according to the return type signature specified in \code{signature} .
-Aggregate by-value callback arguments and returns are currently unsupported.
+
+Aggregate by-value callback arguments and returns use the same \verb{<Type>}
+signature syntax as \code{\link[=dyncall]{dyncall()}}. An aggregate argument is passed to the R
+callback as a raw-backed \code{cdata} object with \code{struct} and \code{typeinfo}
+attributes. An aggregate return value must be a raw-backed object for the
+same aggregate type and size. Type or storage mismatches disable the callback
+and emit a warning.
+
+Aggregate callbacks are supported on the implemented 64-bit x86 and ARM64
+dyncallback backends. On unsupported backends, creating a callback whose
+signature contains \verb{<Type>} fails early.
+
 If an error occurs during the evaluation, the callback will be disabled for
 further invocations. (This behaviour might change in the future.)
 }

--- a/man/rdyncall-package.Rd
+++ b/man/rdyncall-package.Rd
@@ -27,7 +27,7 @@ through raw-backed \code{\link[=cdata]{cdata()}} objects. The aggregate layout s
 ordinary struct and union fields, fixed-size array fields, integer bitfields,
 packed layouts, manual alignment directives and by-value aggregate calls on
 supported DynCall backends. Aggregate by-value callback arguments and returns
-are currently unsupported.
+are supported on implemented 64-bit x86 and ARM64 dyncallback backends.
 
 R functions can be wrapped as C function pointers with \code{\link[=ccallback]{ccallback()}}. Keep an
 R reference to callback objects for as long as foreign code may call them.

--- a/src/dyncall/dyncall/dyncall_callvm_arm64_aggr.c
+++ b/src/dyncall/dyncall/dyncall_callvm_arm64_aggr.c
@@ -44,8 +44,10 @@ static DCsize dc_arm64_align_up(DCsize x, DCsize align)
 
 static DCsize dc_arm64_stack_align(const DCaggr* ag)
 {
-  DCsize align = ag && ag->alignment ? ag->alignment : 1;
-  return align > 8 ? 8 : align;
+  (void)ag;
+  /* AAPCS64 stack aggregate arguments use 8-byte argument slots. The
+     aggregate's own alignment is for object layout, not stack slot placement. */
+  return 8;
 }
 
 static void dc_arm64_append_stack(DCCallVM_arm64* self, const void* x, DCsize size, DCsize align, int pad_to_8)
@@ -201,8 +203,10 @@ static void dc_callvm_argAggr_arm64(DCCallVM* in_self, const DCaggr* ag, const v
   if(dc_arm64_is_hfa(ag, &hfa_type, &hfa_count)) {
     if(self->f + hfa_count <= DC_ARM64_NUM_REGS)
       dc_arm64_copy_hfa_to_regs(self, ag, (const DCchar*)x, hfa_type);
-    else
+    else {
       dc_arm64_append_stack(self, x, ag->size, dc_arm64_stack_align(ag), 1);
+      self->f = DC_ARM64_NUM_REGS;
+    }
     return;
   }
 
@@ -218,6 +222,7 @@ static void dc_callvm_argAggr_arm64(DCCallVM* in_self, const DCaggr* ag, const v
   }
 
   dc_arm64_append_stack(self, x, ag->size, dc_arm64_stack_align(ag), 1);
+  self->i = DC_ARM64_NUM_REGS;
 }
 
 static void dc_callvm_argAggr_arm64_vararg(DCCallVM* in_self, const DCaggr* ag, const void* x)

--- a/src/dyncall/dyncallback/dyncall_args_arm64.c
+++ b/src/dyncall/dyncallback/dyncall_args_arm64.c
@@ -24,8 +24,10 @@
 */
 
 #include "dyncall_args.h"
+#include "dyncall_aggregate.h"
 
 #include <stdint.h>
+#include <string.h>
 
 typedef union {
   struct { double value; } d;
@@ -42,6 +44,9 @@ struct DCArgs
   /* counters: */
   int i;
   int f;
+
+  DCaggr** aggrs;
+  DCpointer aggr_return_ptr;
 };
 
 DClonglong  dcbArgLongLong (DCArgs* p) { return (p->i < 8) ? p->I[p->i++] : *(p->sp)++; }
@@ -62,6 +67,191 @@ DCushort    dcbArgUShort   (DCArgs* p) { return (DCushort)   dcbArgShort(p);    
 DCulong     dcbArgULong    (DCArgs* p) { return (DCulong)    dcbArgLong(p);     }
 DCulonglong dcbArgULongLong(DCArgs* p) { return (DCulonglong)dcbArgLongLong(p); }
 
-DCpointer   dcbArgAggr     (DCArgs* p, DCpointer target)                   { /* @@@AGGR not impl */ return NULL; }
-void        dcbReturnAggr  (DCArgs *args, DCValue *result, DCpointer ret)  { /* @@@AGGR not impl */ }
+#define DCB_ARM64_NUM_REGS 8
+#define DCB_ARM64_MAX_HFA_FIELDS 4
 
+static DCsize dcb_arm64_align_up(DCsize x, DCsize align)
+{
+  DCsize rem;
+  if(align <= 1)
+    return x;
+  rem = x % align;
+  return rem ? x + align - rem : x;
+}
+
+static DCsize dcb_arm64_stack_align(const DCaggr* ag)
+{
+  (void)ag;
+  /* Match the call-side AAPCS64 aggregate stack rule: stack arguments occupy
+     8-byte slots regardless of the aggregate object's natural alignment. */
+  return 8;
+}
+
+static int dcb_arm64_hfa_scan(const DCaggr* ag, DCsigchar* type, DCint* count)
+{
+  DCsize i;
+
+  for(i = 0; i < ag->n_fields; ++i) {
+    const DCfield* f = ag->fields + i;
+    DCsize j;
+
+    for(j = 0; j < f->array_len; ++j) {
+      if(f->type == DC_SIGCHAR_AGGREGATE) {
+        if(!dcb_arm64_hfa_scan(f->sub_aggr, type, count))
+          return 0;
+      } else if(f->type == DC_SIGCHAR_FLOAT || f->type == DC_SIGCHAR_DOUBLE) {
+        if(*type == '\0')
+          *type = f->type;
+        else if(*type != f->type)
+          return 0;
+        if(++(*count) > DCB_ARM64_MAX_HFA_FIELDS)
+          return 0;
+      } else {
+        return 0;
+      }
+    }
+  }
+
+  return 1;
+}
+
+static int dcb_arm64_is_hfa(const DCaggr* ag, DCsigchar* type, DCint* count)
+{
+  *type = '\0';
+  *count = 0;
+  return ag && dcb_arm64_hfa_scan(ag, type, count) && *count > 0;
+}
+
+static void dcb_arm64_copy_hfa_from_regs(const DCaggr* ag, DCchar* base, DCArgs* p, DCsigchar type)
+{
+  DCsize i;
+
+  for(i = 0; i < ag->n_fields; ++i) {
+    const DCfield* f = ag->fields + i;
+    DCsize j;
+
+    for(j = 0; j < f->array_len; ++j) {
+      DCchar* dst = base + f->offset + j * f->size;
+      if(f->type == DC_SIGCHAR_AGGREGATE) {
+        dcb_arm64_copy_hfa_from_regs(f->sub_aggr, dst, p, type);
+      } else if(type == DC_SIGCHAR_FLOAT) {
+        DCfloat x = p->F[p->f++].f.value;
+        memcpy(dst, &x, sizeof(x));
+      } else {
+        DCdouble x = p->F[p->f++].d.value;
+        memcpy(dst, &x, sizeof(x));
+      }
+    }
+  }
+}
+
+static void dcb_arm64_copy_hfa_to_result(const DCaggr* ag, const DCchar* base, DCchar* out, DCsigchar type, DCint* index)
+{
+  DCsize i;
+
+  for(i = 0; i < ag->n_fields; ++i) {
+    const DCfield* f = ag->fields + i;
+    DCsize j;
+
+    for(j = 0; j < f->array_len; ++j) {
+      const DCchar* src = base + f->offset + j * f->size;
+      if(f->type == DC_SIGCHAR_AGGREGATE) {
+        dcb_arm64_copy_hfa_to_result(f->sub_aggr, src, out, type, index);
+      } else if(type == DC_SIGCHAR_FLOAT) {
+        memset(out + (*index * 8), 0, 8);
+        memcpy(out + (*index * 8), src, sizeof(DCfloat));
+        ++(*index);
+      } else {
+        memcpy(out + (*index * 8), src, sizeof(DCdouble));
+        ++(*index);
+      }
+    }
+  }
+}
+
+static void dcb_arm64_copy_stack(DCArgs* p, DCpointer target, DCsize size, DCsize align)
+{
+  uint8_t *sp = (uint8_t*)p->sp;
+  DCsize advance;
+  if(align > 1)
+    sp = (uint8_t*)dcb_arm64_align_up((DCsize)sp, align);
+  memcpy(target, sp, size);
+  advance = dcb_arm64_align_up(size, 8);
+  p->sp = (uint64_t*)(sp + advance);
+}
+
+DCpointer dcbArgAggr(DCArgs* p, DCpointer target)
+{
+  DCaggr *ag = *(p->aggrs++);
+  DCsigchar hfa_type;
+  DCint hfa_count;
+
+  if(!ag)
+    return dcbArgPointer(p);
+  if(!target)
+    return NULL;
+
+  if(dcb_arm64_is_hfa(ag, &hfa_type, &hfa_count)) {
+    if(p->f + hfa_count <= DCB_ARM64_NUM_REGS)
+      dcb_arm64_copy_hfa_from_regs(ag, (DCchar*)target, p, hfa_type);
+    else {
+      dcb_arm64_copy_stack(p, target, ag->size, dcb_arm64_stack_align(ag));
+      p->f = DCB_ARM64_NUM_REGS;
+    }
+    return target;
+  }
+
+  if(ag->size > 16) {
+    DCpointer src = dcbArgPointer(p);
+    memcpy(target, src, ag->size);
+    return target;
+  }
+
+  {
+    DCsize chunk_count = dcb_arm64_align_up(ag->size, 8) >> 3;
+    if(p->i + chunk_count <= DCB_ARM64_NUM_REGS) {
+      DCsize i;
+      DCchar *dst = (DCchar*)target;
+      memset(target, 0, ag->size);
+      for(i = 0; i < chunk_count; ++i) {
+        DCsize remaining = ag->size > i * 8 ? ag->size - i * 8 : 0;
+        DCsize n = remaining > 8 ? 8 : remaining;
+        if(n)
+          memcpy(dst + i * 8, &p->I[p->i], n);
+        ++p->i;
+      }
+    } else {
+      dcb_arm64_copy_stack(p, target, ag->size, dcb_arm64_stack_align(ag));
+      p->i = DCB_ARM64_NUM_REGS;
+    }
+  }
+
+  return target;
+}
+
+void dcbReturnAggr(DCArgs *args, DCValue *result, DCpointer ret)
+{
+  DCaggr *ag = *(args->aggrs++);
+  DCsigchar hfa_type;
+  DCint hfa_count;
+
+  if(args->aggr_return_ptr) {
+    if(ag && ret)
+      memcpy(args->aggr_return_ptr, ret, ag->size);
+    result->p = args->aggr_return_ptr;
+    return;
+  }
+
+  if(!ag || !ret)
+    return;
+
+  if(dcb_arm64_is_hfa(ag, &hfa_type, &hfa_count)) {
+    DCint index = 0;
+    (void)hfa_count;
+    memset(result, 0, 32);
+    dcb_arm64_copy_hfa_to_result(ag, (const DCchar*)ret, (DCchar*)result, hfa_type, &index);
+  } else {
+    memset(result, 0, 16);
+    memcpy(result, ret, ag->size);
+  }
+}

--- a/src/dyncall/dyncallback/dyncall_args_arm64_apple.c
+++ b/src/dyncall/dyncallback/dyncall_args_arm64_apple.c
@@ -24,8 +24,10 @@
 */
 
 #include "dyncall_args.h"
+#include "dyncall_aggregate.h"
 
 #include <stdint.h>
+#include <string.h>
 
 typedef union {
   struct { double value; } d;
@@ -42,6 +44,9 @@ struct DCArgs
   /* counters: */
   int i;
   int f;
+
+  DCaggr** aggrs;
+  DCpointer aggr_return_ptr;
 };
 
 static inline uint8_t* align(uint8_t* p, size_t v)
@@ -164,6 +169,187 @@ DCushort    dcbArgUShort   (DCArgs* p) { return (DCushort)    dcbArgShort(p);   
 DCulong     dcbArgULong    (DCArgs* p) { return (DCulong)     dcbArgLong(p);     }
 DCulonglong dcbArgULongLong(DCArgs* p) { return (DCulonglong) dcbArgLongLong(p); }
 
-DCpointer   dcbArgAggr     (DCArgs* p, DCpointer target)                   { /* @@@AGGR not impl */ return NULL; }
-void        dcbReturnAggr  (DCArgs *args, DCValue *result, DCpointer ret)  { /* @@@AGGR not impl */ }
+#define DCB_ARM64_NUM_REGS 8
+#define DCB_ARM64_MAX_HFA_FIELDS 4
 
+static size_t dcb_arm64_align_up(size_t x, size_t alignment)
+{
+  size_t rem;
+  if(alignment <= 1)
+    return x;
+  rem = x % alignment;
+  return rem ? x + alignment - rem : x;
+}
+
+static size_t dcb_arm64_stack_align(const DCaggr* ag)
+{
+  (void)ag;
+  /* Match the call-side AAPCS64 aggregate stack rule: stack arguments occupy
+     8-byte slots regardless of the aggregate object's natural alignment. */
+  return 8;
+}
+
+static int dcb_arm64_hfa_scan(const DCaggr* ag, DCsigchar* type, DCint* count)
+{
+  DCsize i;
+
+  for(i = 0; i < ag->n_fields; ++i) {
+    const DCfield* f = ag->fields + i;
+    DCsize j;
+
+    for(j = 0; j < f->array_len; ++j) {
+      if(f->type == DC_SIGCHAR_AGGREGATE) {
+        if(!dcb_arm64_hfa_scan(f->sub_aggr, type, count))
+          return 0;
+      } else if(f->type == DC_SIGCHAR_FLOAT || f->type == DC_SIGCHAR_DOUBLE) {
+        if(*type == '\0')
+          *type = f->type;
+        else if(*type != f->type)
+          return 0;
+        if(++(*count) > DCB_ARM64_MAX_HFA_FIELDS)
+          return 0;
+      } else {
+        return 0;
+      }
+    }
+  }
+
+  return 1;
+}
+
+static int dcb_arm64_is_hfa(const DCaggr* ag, DCsigchar* type, DCint* count)
+{
+  *type = '\0';
+  *count = 0;
+  return ag && dcb_arm64_hfa_scan(ag, type, count) && *count > 0;
+}
+
+static void dcb_arm64_copy_hfa_from_regs(const DCaggr* ag, DCchar* base, DCArgs* p, DCsigchar type)
+{
+  DCsize i;
+
+  for(i = 0; i < ag->n_fields; ++i) {
+    const DCfield* f = ag->fields + i;
+    DCsize j;
+
+    for(j = 0; j < f->array_len; ++j) {
+      DCchar* dst = base + f->offset + j * f->size;
+      if(f->type == DC_SIGCHAR_AGGREGATE) {
+        dcb_arm64_copy_hfa_from_regs(f->sub_aggr, dst, p, type);
+      } else if(type == DC_SIGCHAR_FLOAT) {
+        DCfloat x = p->F[p->f++].f.value;
+        memcpy(dst, &x, sizeof(x));
+      } else {
+        DCdouble x = p->F[p->f++].d.value;
+        memcpy(dst, &x, sizeof(x));
+      }
+    }
+  }
+}
+
+static void dcb_arm64_copy_hfa_to_result(const DCaggr* ag, const DCchar* base, DCchar* out, DCsigchar type, DCint* index)
+{
+  DCsize i;
+
+  for(i = 0; i < ag->n_fields; ++i) {
+    const DCfield* f = ag->fields + i;
+    DCsize j;
+
+    for(j = 0; j < f->array_len; ++j) {
+      const DCchar* src = base + f->offset + j * f->size;
+      if(f->type == DC_SIGCHAR_AGGREGATE) {
+        dcb_arm64_copy_hfa_to_result(f->sub_aggr, src, out, type, index);
+      } else if(type == DC_SIGCHAR_FLOAT) {
+        memset(out + (*index * 8), 0, 8);
+        memcpy(out + (*index * 8), src, sizeof(DCfloat));
+        ++(*index);
+      } else {
+        memcpy(out + (*index * 8), src, sizeof(DCdouble));
+        ++(*index);
+      }
+    }
+  }
+}
+
+static void dcb_arm64_copy_stack(DCArgs* p, DCpointer target, DCsize size, size_t alignment)
+{
+  p->sp = align(p->sp, alignment);
+  memcpy(target, p->sp, size);
+  p->sp += dcb_arm64_align_up(size, 8);
+}
+
+DCpointer dcbArgAggr(DCArgs* p, DCpointer target)
+{
+  DCaggr *ag = *(p->aggrs++);
+  DCsigchar hfa_type;
+  DCint hfa_count;
+
+  if(!ag)
+    return dcbArgPointer(p);
+  if(!target)
+    return NULL;
+
+  if(dcb_arm64_is_hfa(ag, &hfa_type, &hfa_count)) {
+    if(p->f + hfa_count <= DCB_ARM64_NUM_REGS)
+      dcb_arm64_copy_hfa_from_regs(ag, (DCchar*)target, p, hfa_type);
+    else {
+      dcb_arm64_copy_stack(p, target, ag->size, dcb_arm64_stack_align(ag));
+      p->f = DCB_ARM64_NUM_REGS;
+    }
+    return target;
+  }
+
+  if(ag->size > 16) {
+    DCpointer src = dcbArgPointer(p);
+    memcpy(target, src, ag->size);
+    return target;
+  }
+
+  {
+    DCsize chunk_count = dcb_arm64_align_up(ag->size, 8) >> 3;
+    if(p->i + chunk_count <= DCB_ARM64_NUM_REGS) {
+      DCsize i;
+      DCchar *dst = (DCchar*)target;
+      memset(target, 0, ag->size);
+      for(i = 0; i < chunk_count; ++i) {
+        DCsize remaining = ag->size > i * 8 ? ag->size - i * 8 : 0;
+        DCsize n = remaining > 8 ? 8 : remaining;
+        if(n)
+          memcpy(dst + i * 8, &p->I[p->i], n);
+        ++p->i;
+      }
+    } else {
+      dcb_arm64_copy_stack(p, target, ag->size, dcb_arm64_stack_align(ag));
+      p->i = DCB_ARM64_NUM_REGS;
+    }
+  }
+
+  return target;
+}
+
+void dcbReturnAggr(DCArgs *args, DCValue *result, DCpointer ret)
+{
+  DCaggr *ag = *(args->aggrs++);
+  DCsigchar hfa_type;
+  DCint hfa_count;
+
+  if(args->aggr_return_ptr) {
+    if(ag && ret)
+      memcpy(args->aggr_return_ptr, ret, ag->size);
+    result->p = args->aggr_return_ptr;
+    return;
+  }
+
+  if(!ag || !ret)
+    return;
+
+  if(dcb_arm64_is_hfa(ag, &hfa_type, &hfa_count)) {
+    DCint index = 0;
+    (void)hfa_count;
+    memset(result, 0, 32);
+    dcb_arm64_copy_hfa_to_result(ag, (const DCchar*)ret, (DCchar*)result, hfa_type, &index);
+  } else {
+    memset(result, 0, 16);
+    memcpy(result, ret, ag->size);
+  }
+}

--- a/src/dyncall/dyncallback/dyncall_callback_arm64.S
+++ b/src/dyncall/dyncallback/dyncall_callback_arm64.S
@@ -32,6 +32,9 @@ BEGIN_ASM
      DCThunk  |   0  |  32
      handler  |  32  |   8
      userdata |  40  |   8
+     aggrs    |  48  |   8
+     aggr ret |  56  |   4
+     aggr cnt |  60  |   4
 */
 
 TEXTAREA
@@ -50,11 +53,11 @@ ALIGN(4)
      type       off   size
      ---------|------|------
      Frame        0     16
-     DCArgs      16    144
-     DCValue    160     16
+     DCArgs      16    160
+     DCValue    176     48
 
-     size              176
-     aligned           176
+     size              224
+     aligned           224
 
 
    locals:
@@ -63,7 +66,7 @@ ALIGN(4)
 */
 
 	mov x10, sp
-	stp x29, x30, [sp, #-176 ]!
+	stp x29, x30, [sp, #-224 ]!
 	mov x29, sp
 
 	add x11, x29 , #16
@@ -82,34 +85,64 @@ ALIGN(4)
 
 	eor x12, x12, x12
 	stp x10,x12,[x11, #128]		/* sp=sp, i=0, f=0 */
+	ldr x13, [x9, #48]
+	str x13, [x11, #144]		/* aggrs */
+	ldr w13, [x9, #56]
+	cmp w13, #0
+	csel x13, x8, xzr, eq
+	str x13, [x11, #152]		/* aggregate return pointer */
 
 
 /* call handler/callback */
 
 	mov x0 , x9          /* DCCallback* pcb      */
 	add x1 , x29 , #16   /* DCArgs*     args     */
-	add x2 , x29 , #160  /* DCValue*    result   */
+	add x2 , x29 , #176  /* DCValue*    result   */
 	ldr x3 , [x9 , #40]  /* void*       userdata */
 
 	ldr x11, [x9 , #32]
+	str x9, [x29, #216]
 	blr x11
 
+	ldr x14, [x29, #216]
+	add x15, x29, #16
 	and w0, w0, #255
+	cmp w0, 'A'
+	b.eq LABELUSE(reta)
 	cmp w0, 'f'
 	b.eq LABELUSE(retf)
 	cmp w0, 'd'
 	b.eq LABELUSE(retf)
 
 LABELDEF(reti)
-	ldr x0, [x29, #160]
+	ldr x0, [x29, #176]
 	b LABELUSE(ret)
 LABELDEF(retf)
-	ldr d0, [x29, #160]
+	ldr d0, [x29, #176]
+	b LABELUSE(ret)
+LABELDEF(reta)
+	ldr w10, [x14, #56]
+	cmp w10, #1
+	b.eq LABELUSE(retai)
+	cmp w10, #2
+	b.eq LABELUSE(retaf)
+	cmp w10, #3
+	b.eq LABELUSE(retaf)
+	ldr x0, [x15, #152]
+	b LABELUSE(ret)
+LABELDEF(retai)
+	ldr x0, [x29, #176]
+	ldr x1, [x29, #184]
+	b LABELUSE(ret)
+LABELDEF(retaf)
+	ldr d0, [x29, #176]
+	ldr d1, [x29, #184]
+	ldr d2, [x29, #192]
+	ldr d3, [x29, #200]
 LABELDEF(ret)
-	ldp x29, x30, [sp], #176
+	ldp x29, x30, [sp], #224
 	ret
 
 
 END_PROC
 END_ASM
-

--- a/src/dyncall/dyncallback/dyncall_callback_arm64.c
+++ b/src/dyncall/dyncallback/dyncall_callback_arm64.c
@@ -26,24 +26,104 @@
 
 #include "dyncall_callback.h"
 #include "dyncall_alloc_wx.h"
+#include "dyncall_aggregate.h"
 #include "dyncall_thunk.h"
+
+#define DCB_ARM64_AGGR_RET_NONE   -2
+#define DCB_ARM64_AGGR_RET_HIDDEN  0
+#define DCB_ARM64_AGGR_RET_INT     1
+#define DCB_ARM64_AGGR_RET_FLOAT   2
+#define DCB_ARM64_AGGR_RET_DOUBLE  3
+#define DCB_ARM64_MAX_HFA_FIELDS   4
 
 
 /* Callback symbol. */
 extern void dcCallbackThunkEntry();
 
-struct DCCallback               /*  off  size */
-{                               /* ----|----- */
-  DCThunk            thunk;     /*   0     32 */
-  DCCallbackHandler* handler;   /*  32      8 */
-  void*              userdata;  /*  40      8 */
-};                              /* total   48 */ 
-                                /* aligned 48 */ 
+struct DCCallback                    /*  off  size */
+{                                    /* ----|----- */
+  DCThunk            thunk;          /*   0     32 */
+  DCCallbackHandler* handler;        /*  32      8 */
+  void*              userdata;       /*  40      8 */
+  DCaggr *const *    aggrs;          /*  48      8 */
+  DCint              aggr_ret_mode;  /*  56      4 */
+  DCint              aggr_ret_count; /*  60      4 */
+};                                   /* total   64 */
+                                     /* aligned 64 */
+
+static int dcb_arm64_hfa_scan(const DCaggr* ag, DCsigchar* type, DCint* count)
+{
+  DCsize i;
+
+  for(i = 0; i < ag->n_fields; ++i) {
+    const DCfield* f = ag->fields + i;
+    DCsize j;
+
+    for(j = 0; j < f->array_len; ++j) {
+      if(f->type == DC_SIGCHAR_AGGREGATE) {
+        if(!dcb_arm64_hfa_scan(f->sub_aggr, type, count))
+          return 0;
+      } else if(f->type == DC_SIGCHAR_FLOAT || f->type == DC_SIGCHAR_DOUBLE) {
+        if(*type == '\0')
+          *type = f->type;
+        else if(*type != f->type)
+          return 0;
+        if(++(*count) > DCB_ARM64_MAX_HFA_FIELDS)
+          return 0;
+      } else {
+        return 0;
+      }
+    }
+  }
+
+  return 1;
+}
+
+static int dcb_arm64_is_hfa(const DCaggr* ag, DCsigchar* type, DCint* count)
+{
+  *type = '\0';
+  *count = 0;
+  return ag && dcb_arm64_hfa_scan(ag, type, count) && *count > 0;
+}
 
 void dcbInitCallback2(DCCallback* pcb, const DCsigchar* signature, DCCallbackHandler* handler, void* userdata, DCaggr *const * aggrs)
 {
+  const DCsigchar *ch = signature;
+  DCint num_aggrs = 0;
+
   pcb->handler = handler;
   pcb->userdata = userdata;
+  pcb->aggrs = NULL;
+  pcb->aggr_ret_mode = DCB_ARM64_AGGR_RET_NONE;
+  pcb->aggr_ret_count = 0;
+
+  if(*ch == DC_SIGCHAR_CC_PREFIX)
+    ch += 2;
+
+  while(*ch)
+    num_aggrs += (*(ch++) == DC_SIGCHAR_AGGREGATE);
+
+  if(num_aggrs) {
+    pcb->aggrs = aggrs;
+
+    if(ch != signature && *(ch - 1) == DC_SIGCHAR_AGGREGATE) {
+      const DCaggr *ag = pcb->aggrs[num_aggrs - 1];
+      DCsigchar hfa_type;
+      DCint hfa_count;
+
+      if(!ag) {
+        pcb->aggr_ret_mode = DCB_ARM64_AGGR_RET_HIDDEN;
+      } else if(dcb_arm64_is_hfa(ag, &hfa_type, &hfa_count)) {
+        pcb->aggr_ret_mode = hfa_type == DC_SIGCHAR_FLOAT ?
+          DCB_ARM64_AGGR_RET_FLOAT : DCB_ARM64_AGGR_RET_DOUBLE;
+        pcb->aggr_ret_count = hfa_count;
+      } else if(ag->size > 16) {
+        pcb->aggr_ret_mode = DCB_ARM64_AGGR_RET_HIDDEN;
+      } else {
+        pcb->aggr_ret_mode = DCB_ARM64_AGGR_RET_INT;
+      }
+    }
+  }
 }
 
 
@@ -65,4 +145,3 @@ DCCallback* dcbNewCallback2(const DCsigchar* signature, DCCallbackHandler* handl
 
   return pcb;
 }
-

--- a/src/dyncall/dyncallback/dyncall_callback_arm64_masm.asm
+++ b/src/dyncall/dyncallback/dyncall_callback_arm64_masm.asm
@@ -2,7 +2,7 @@
  EXPORT dcCallbackThunkEntry
 dcCallbackThunkEntry PROC
  mov x10, sp
- stp x29, x30, [sp, #-208 ]!
+ stp x29, x30, [sp, #-224 ]!
  mov x29, sp
  add x11, x29 , #16
  stp x0, x1, [x11, #0 ]
@@ -12,28 +12,58 @@ dcCallbackThunkEntry PROC
  stp d0, d1, [x11, #64]
  stp d2, d3, [x11, #80]
       stp d4, d5, [x11, #96]
-        stp d6, d7, [x11, #112]
+ stp d6, d7, [x11, #112]
  eor x12, x12, x12
  stp x10,x12,[x11, #128]
- str x12, [x11, #144]
+ ldr x13, [x9, #48]
+ str x13, [x11, #144]
+ ldr w13, [x9, #56]
+ cmp w13, #0
+ csel x13, x8, xzr, eq
+ str x13, [x11, #152]
  mov x0 , x9
  add x1 , x29 , #16
- add x2 , x29 , #184
+ add x2 , x29 , #176
  ldr x3 , [x9 , #40]
  ldr x11, [x9 , #32]
+ str x9, [x29, #216]
  blr x11
+ ldr x14, [x29, #216]
+ add x15, x29, #16
  and w0, w0, #255
+ cmp w0, 'A'
+ b.eq dcCall_arm64_reta
  cmp w0, 'f'
  b.eq dcCall_arm64_retf
  cmp w0, 'd'
  b.eq dcCall_arm64_retf
 dcCall_arm64_reti
- ldr x0, [x29, #184]
+ ldr x0, [x29, #176]
  b dcCall_arm64_ret
 dcCall_arm64_retf
- ldr d0, [x29, #184]
+ ldr d0, [x29, #176]
+ b dcCall_arm64_ret
+dcCall_arm64_reta
+ ldr w10, [x14, #56]
+ cmp w10, #1
+ b.eq dcCall_arm64_retai
+ cmp w10, #2
+ b.eq dcCall_arm64_retaf
+ cmp w10, #3
+ b.eq dcCall_arm64_retaf
+ ldr x0, [x15, #152]
+ b dcCall_arm64_ret
+dcCall_arm64_retai
+ ldr x0, [x29, #176]
+ ldr x1, [x29, #184]
+ b dcCall_arm64_ret
+dcCall_arm64_retaf
+ ldr d0, [x29, #176]
+ ldr d1, [x29, #184]
+ ldr d2, [x29, #192]
+ ldr d3, [x29, #200]
 dcCall_arm64_ret
- ldp x29, x30, [sp], #208
+ ldp x29, x30, [sp], #224
  ret
  ENDP
  END

--- a/src/rcallback.c
+++ b/src/rcallback.c
@@ -8,21 +8,184 @@
 #include "Rdefines.h"
 #include <R_ext/Memory.h>
 #include "dyncall_callback.h"
+#include "dyncall_aggregate.h"
+#include "rdyncall_signature.h"
+#include <string.h>
+
+#define RDYNCALL_CALLBACK_MAX_AGGRS 256
+
+#if defined(DC__Feature_AggrByVal) && (defined(DC__Arch_AMD64) || defined(DC__Arch_ARM64))
+#define RDYNCALL_HAS_CALLBACK_AGGR_BYVAL 1
+#endif
 
 typedef struct
 {
   int         disabled;
+  SEXP        signature_x;
   SEXP        fun;
   SEXP        rho;
+  SEXP        aggr_typeinfos;
   int         nargs;
+  int         naggrs;
+  int         aggr_count;
   const char* signature; /* argument signature without call mode prefix */
+  DCaggr**    callback_aggrs;
+  DCaggr**    all_aggrs;
 } R_Callback;
+
+static SEXP rcallback_get_list_element(SEXP list, const char *name)
+{
+  SEXP names = Rf_getAttrib(list, R_NamesSymbol);
+  if (names == R_NilValue) return R_NilValue;
+  for (R_xlen_t i = 0; i < XLENGTH(list); i++) {
+    if (strcmp(CHAR(STRING_ELT(names, i)), name) == 0) {
+      return VECTOR_ELT(list, i);
+    }
+  }
+  return R_NilValue;
+}
+
+static int rcallback_scalar_int(SEXP x, const char *name)
+{
+  if (TYPEOF(x) == INTSXP && XLENGTH(x) > 0) return INTEGER(x)[0];
+  if (TYPEOF(x) == REALSXP && XLENGTH(x) > 0) return (int) REAL(x)[0];
+  Rf_error("internal error: aggregate layout field '%s' is not an integer scalar", name);
+  return 0;
+}
+
+static int rcallback_layout_size(SEXP layout)
+{
+  return rcallback_scalar_int(rcallback_get_list_element(layout, "size"), "size");
+}
+
+static int rcallback_layout_align(SEXP layout)
+{
+  return rcallback_scalar_int(rcallback_get_list_element(layout, "align"), "align");
+}
+
+static const char* rcallback_typeinfo_name(SEXP typeinfo)
+{
+  SEXP name = rcallback_get_list_element(typeinfo, "name");
+  if (TYPEOF(name) != STRSXP || XLENGTH(name) < 1) {
+    Rf_error("internal error: aggregate typeinfo is missing a name");
+  }
+  return CHAR(STRING_ELT(name, 0));
+}
+
+static DCsigchar rcallback_aggregate_field_sigchar(const char *type)
+{
+  if (type[0] == '*') return DC_SIGCHAR_POINTER;
+  switch(type[0]) {
+    case DC_SIGCHAR_BOOL:
+    case DC_SIGCHAR_CHAR:
+    case DC_SIGCHAR_UCHAR:
+    case DC_SIGCHAR_SHORT:
+    case DC_SIGCHAR_USHORT:
+    case DC_SIGCHAR_INT:
+    case DC_SIGCHAR_UINT:
+    case DC_SIGCHAR_LONG:
+    case DC_SIGCHAR_ULONG:
+    case DC_SIGCHAR_LONGLONG:
+    case DC_SIGCHAR_ULONGLONG:
+    case DC_SIGCHAR_FLOAT:
+    case DC_SIGCHAR_DOUBLE:
+    case DC_SIGCHAR_POINTER:
+    case DC_SIGCHAR_STRING:
+      return type[0];
+    case DC_SIGCHAR_SEXP:
+      return DC_SIGCHAR_POINTER;
+    default:
+      Rf_error("unsupported aggregate field type '%s'", type);
+      return DC_SIGCHAR_VOID;
+  }
+}
+
+static DCaggr* rcallback_new_aggr(SEXP layout, DCaggr **aggrs, int *aggr_count)
+{
+  int size = rcallback_layout_size(layout);
+  int alignment = rcallback_layout_align(layout);
+  SEXP fields = rcallback_get_list_element(layout, "fields");
+  SEXP field_layouts = rcallback_get_list_element(layout, "field_layouts");
+  SEXP types = rcallback_get_list_element(fields, "type");
+  SEXP offsets = rcallback_get_list_element(fields, "offset");
+  SEXP array_lens = rcallback_get_list_element(fields, "array_len");
+
+  if (TYPEOF(fields) != VECSXP || TYPEOF(types) != STRSXP || TYPEOF(offsets) != INTSXP ||
+      TYPEOF(field_layouts) != VECSXP) {
+    Rf_error("internal error: invalid aggregate field layout");
+  }
+
+  R_xlen_t nfields = XLENGTH(types);
+  if (XLENGTH(field_layouts) < nfields) {
+    Rf_error("internal error: invalid nested aggregate field layout");
+  }
+  if (array_lens != R_NilValue && (TYPEOF(array_lens) != INTSXP || XLENGTH(array_lens) < nfields)) {
+    Rf_error("internal error: invalid aggregate field array lengths");
+  }
+  if (*aggr_count >= RDYNCALL_CALLBACK_MAX_AGGRS) {
+    Rf_error("too many aggregate by-value descriptors");
+  }
+
+  DCaggr *ag = dcNewAggr((DCsize) nfields, (DCsize) size);
+  aggrs[*aggr_count] = ag;
+  *aggr_count += 1;
+
+  for (R_xlen_t i = 0; i < nfields; i++) {
+    const char *type = CHAR(STRING_ELT(types, i));
+    int array_len = array_lens == R_NilValue ? 1 : INTEGER(array_lens)[i];
+    if (array_len < 1) {
+      Rf_error("internal error: invalid aggregate field array length");
+    }
+    if (type[0] == '<') {
+      SEXP sub_layout = VECTOR_ELT(field_layouts, i);
+      if (sub_layout == R_NilValue) {
+        Rf_error("internal error: missing nested aggregate field layout");
+      }
+      DCaggr *sub_ag = rcallback_new_aggr(sub_layout, aggrs, aggr_count);
+      dcAggrField(ag, DC_SIGCHAR_AGGREGATE, INTEGER(offsets)[i], (DCsize) array_len, sub_ag);
+    } else {
+      dcAggrField(ag, rcallback_aggregate_field_sigchar(type), INTEGER(offsets)[i], (DCsize) array_len);
+    }
+  }
+  ag->alignment = (DCsize) alignment;
+  dcCloseAggr(ag);
+  return ag;
+}
+
+static void rcallback_free_aggrs(R_Callback *rdata)
+{
+  if (!rdata || !rdata->all_aggrs) return;
+  for (int i = 0; i < rdata->aggr_count; i++) {
+    if (rdata->all_aggrs[i]) dcFreeAggr(rdata->all_aggrs[i]);
+  }
+}
+
+static void rcallback_set_struct_attrib(SEXP x, SEXP typeinfo)
+{
+  const char *name = rcallback_typeinfo_name(typeinfo);
+  Rf_setAttrib(x, Rf_install("struct"), Rf_mkString(name));
+  Rf_setAttrib(x, Rf_install("typeinfo"), typeinfo);
+  Rf_setAttrib(x, R_ClassSymbol, Rf_mkString("struct"));
+}
+
+static int rcallback_expect_struct(SEXP x, SEXP typeinfo, int size)
+{
+  if (TYPEOF(x) != RAWSXP || XLENGTH(x) < size) return 0;
+
+  SEXP struct_name = Rf_getAttrib(x, Rf_install("struct"));
+  if (TYPEOF(struct_name) != STRSXP || XLENGTH(struct_name) < 1) return 0;
+
+  const char *expected = rcallback_typeinfo_name(typeinfo);
+  const char *actual = CHAR(STRING_ELT(struct_name, 0));
+  return strcmp(actual, expected) == 0;
+}
 
 char R_dcCallbackHandler( DCCallback* pcb, DCArgs* args, DCValue* result, void* userdata )
 {
 	R_Callback* rdata;
 	const char* ptr;
 	int i,n;
+	int aggr_index = 0;
 	SEXP s, x, ans, item;
 	char ch;
 
@@ -44,6 +207,7 @@ char R_dcCallbackHandler( DCCallback* pcb, DCArgs* args, DCValue* result, void* 
 
 	i = 1;
 	for( ;; ++i) {
+		int item_protected = 0;
 		ch = *ptr++;
 		if (ch == ')') break;
 		if (i >= n) {
@@ -68,6 +232,29 @@ char R_dcCallbackHandler( DCCallback* pcb, DCArgs* args, DCValue* result, void* 
 		case DC_SIGCHAR_DOUBLE:    item = ScalarReal( dcbArgDouble(args) ); break;
 		case DC_SIGCHAR_POINTER:   item = R_MakeExternalPtr( dcbArgPointer(args), R_NilValue, R_NilValue ); break;
 		case DC_SIGCHAR_STRING:    item = mkString( dcbArgPointer(args) ); break;
+		case DC_SIGCHAR_AGGREGATE:
+		{
+			SEXP typeinfo;
+			DCaggr *ag;
+			if (aggr_index >= rdata->naggrs) {
+				warning("invalid aggregate callback signature");
+				rdata->disabled = 1;
+				UNPROTECT(1);
+				return DC_SIGCHAR_VOID;
+			}
+			typeinfo = VECTOR_ELT(rdata->aggr_typeinfos, aggr_index);
+			ag = rdata->callback_aggrs[aggr_index++];
+			PROTECT(item = Rf_allocVector(RAWSXP, ag->size));
+			item_protected = 1;
+			if (!dcbArgAggr(args, RAW(item))) {
+				warning("aggregate callback argument is unsupported by this backend");
+				rdata->disabled = 1;
+				UNPROTECT(2);
+				return DC_SIGCHAR_VOID;
+			}
+			rcallback_set_struct_attrib(item, typeinfo);
+			break;
+		}
 		default:
 		case '\0':
 			warning("invalid signature");
@@ -76,6 +263,9 @@ char R_dcCallbackHandler( DCCallback* pcb, DCArgs* args, DCValue* result, void* 
 			return DC_SIGCHAR_VOID;
 		}
 		SETCAR( x, item);
+		if (item_protected) {
+			UNPROTECT(1);
+		}
 		x = CDR(x);
 	}
 
@@ -170,6 +360,25 @@ char R_dcCallbackHandler( DCCallback* pcb, DCArgs* args, DCValue* result, void* 
 			warning("not implemented");
 			rdata->disabled = 1;
 			break;
+		case DC_SIGCHAR_AGGREGATE:
+		{
+			SEXP typeinfo;
+			DCaggr *ag;
+			if (aggr_index >= rdata->naggrs) {
+				warning("invalid aggregate callback return signature");
+				rdata->disabled = 1;
+				break;
+			}
+			typeinfo = VECTOR_ELT(rdata->aggr_typeinfos, aggr_index);
+			ag = rdata->callback_aggrs[aggr_index];
+			if (!rcallback_expect_struct(ans, typeinfo, ag->size)) {
+				warning("aggregate callback return value has incompatible type or storage");
+				rdata->disabled = 1;
+				break;
+			}
+			dcbReturnAggr(args, result, RAW(ans));
+			break;
+		}
 		}
 	}
 	UNPROTECT(2);
@@ -178,19 +387,60 @@ char R_dcCallbackHandler( DCCallback* pcb, DCArgs* args, DCValue* result, void* 
 
 void R_callback_finalizer(SEXP x);
 
-SEXP C_callback(SEXP sig_x, SEXP fun_x, SEXP rho_x)
+SEXP C_callback(SEXP sig_x, SEXP aggr_layouts_x, SEXP aggr_typeinfos_x, SEXP fun_x, SEXP rho_x)
 {
   const char* signature;
   R_Callback* rdata;
   const char* ptr;
   char ch;
+  R_xlen_t naggrs;
+
+  if (TYPEOF(aggr_layouts_x) != VECSXP || TYPEOF(aggr_typeinfos_x) != VECSXP) {
+    Rf_error("internal error: aggregate callback metadata must be lists");
+  }
+  naggrs = XLENGTH(aggr_layouts_x);
+  if (XLENGTH(aggr_typeinfos_x) != naggrs) {
+    Rf_error("internal error: aggregate callback metadata length mismatch");
+  }
+  if (naggrs > RDYNCALL_CALLBACK_MAX_AGGRS) {
+    Rf_error("too many aggregate callback descriptors");
+  }
+
   signature  = CHAR( STRING_ELT( sig_x, 0 ) );
   rdata = R_Calloc(1, R_Callback);
   rdata->disabled = 0;
+  rdata->signature_x = sig_x;
   rdata->fun = fun_x;
   rdata->rho = rho_x;
+  rdata->aggr_typeinfos = aggr_typeinfos_x;
+  rdata->naggrs = (int) naggrs;
+  rdata->aggr_count = 0;
+  rdata->callback_aggrs = NULL;
+  rdata->all_aggrs = NULL;
+  R_PreserveObject(rdata->signature_x);
   R_PreserveObject(rdata->fun);
   R_PreserveObject(rdata->rho);
+  R_PreserveObject(rdata->aggr_typeinfos);
+
+  if (naggrs > 0) {
+#if defined(RDYNCALL_HAS_CALLBACK_AGGR_BYVAL)
+    rdata->callback_aggrs = R_Calloc(naggrs, DCaggr*);
+    rdata->all_aggrs = R_Calloc(RDYNCALL_CALLBACK_MAX_AGGRS, DCaggr*);
+    for (R_xlen_t i = 0; i < naggrs; i++) {
+      rdata->callback_aggrs[i] = rcallback_new_aggr(VECTOR_ELT(aggr_layouts_x, i),
+                                                     rdata->all_aggrs,
+                                                     &rdata->aggr_count);
+    }
+#else
+    R_ReleaseObject(rdata->signature_x);
+    R_ReleaseObject(rdata->fun);
+    R_ReleaseObject(rdata->rho);
+    R_ReleaseObject(rdata->aggr_typeinfos);
+    R_Free(rdata);
+    Rf_error("aggregate by-value callbacks are unsupported by this backend");
+#endif
+  }
+
   ptr = signature;
   // skip call mode signature
   if ( (ch=*ptr) == '_') {
@@ -204,7 +454,20 @@ SEXP C_callback(SEXP sig_x, SEXP fun_x, SEXP rho_x)
     ch = *ptr++;
   }
   rdata->nargs = nargs;
-  DCCallback* cb = dcbNewCallback( signature, R_dcCallbackHandler, rdata);
+  DCCallback* cb = naggrs > 0 ?
+    dcbNewCallback2(signature, R_dcCallbackHandler, rdata, rdata->callback_aggrs) :
+    dcbNewCallback(signature, R_dcCallbackHandler, rdata);
+  if (!cb) {
+    rcallback_free_aggrs(rdata);
+    if (rdata->callback_aggrs) R_Free(rdata->callback_aggrs);
+    if (rdata->all_aggrs) R_Free(rdata->all_aggrs);
+    R_ReleaseObject(rdata->signature_x);
+    R_ReleaseObject(rdata->fun);
+    R_ReleaseObject(rdata->rho);
+    R_ReleaseObject(rdata->aggr_typeinfos);
+    R_Free(rdata);
+    Rf_error("failed to create callback");
+  }
   SEXP ans = R_MakeExternalPtr( cb, R_NilValue, R_NilValue );
   R_RegisterCFinalizerEx(ans, R_callback_finalizer, TRUE);
   return ans;
@@ -213,10 +476,16 @@ SEXP C_callback(SEXP sig_x, SEXP fun_x, SEXP rho_x)
 void R_callback_finalizer(SEXP x)
 {
   DCCallback* cb = R_ExternalPtrAddr(x);
+  if (!cb) return;
   R_Callback* rdata = dcbGetUserData(cb);
+  R_ReleaseObject(rdata->signature_x);
   R_ReleaseObject(rdata->fun);
   R_ReleaseObject(rdata->rho);
+  R_ReleaseObject(rdata->aggr_typeinfos);
+  rcallback_free_aggrs(rdata);
+  if (rdata->callback_aggrs) R_Free(rdata->callback_aggrs);
+  if (rdata->all_aggrs) R_Free(rdata->all_aggrs);
   R_Free(rdata);
   dcbFreeCallback(cb);
+  R_ClearExternalPtr(x);
 }
-

--- a/src/rpackage.c
+++ b/src/rpackage.c
@@ -36,7 +36,7 @@ SEXP C_scan_signature_tokens(SEXP signature);
 SEXP C_scan_field_tail(SEXP tail);
 
 /* rcallback.c */
-SEXP C_callback(SEXP sig, SEXP fun, SEXP rho);
+SEXP C_callback(SEXP sig, SEXP aggr_layouts, SEXP aggr_typeinfos, SEXP fun, SEXP rho);
 
 /* rutils.c */
 SEXP C_asexternalptr(SEXP v);
@@ -82,7 +82,7 @@ R_CallMethodDef callMethods[] =
   {"C_dyncount"                 , (DL_FUNC) &C_dyncount         , 1},
   {"C_dynlist"                  , (DL_FUNC) &C_dynlist          , 1},
   /* --- rcallback.c ------------------------------------------------------- */
-  {"C_callback"                 , (DL_FUNC) &C_callback         , 3},
+  {"C_callback"                 , (DL_FUNC) &C_callback         , 5},
   /* --- rpack.c ----------------------------------------------------------- */
   {"C_pack"                     , (DL_FUNC) &C_pack             , 4},
   {"C_unpack"                   , (DL_FUNC) &C_unpack           , 3},

--- a/vignettes/articles/callbacks.Rmd
+++ b/vignettes/articles/callbacks.Rmd
@@ -96,6 +96,41 @@ The callback object must remain assigned to `compare_ptr` until `qsort()`
 returns. For APIs that store callbacks beyond the registration call, store the
 callback object somewhere with the same lifetime as the foreign registration.
 
+## Aggregate values in callbacks
+
+Callbacks can receive and return registered aggregate types by value with the
+same `<Type>` syntax used by `dyncall()`.
+
+```{r aggregate-callback}
+cstruct("Point{dd}x y;")
+
+point <- cdata(Point)
+point$x <- 1.5
+point$y <- 2.25
+
+point_sum <- ccallback("<Point>)d", function(p) {
+    p$x + p$y
+})
+
+dyncall(point_sum, "<Point>)d", point)
+```
+
+Aggregate arguments arrive as raw-backed `struct` objects, so field access uses
+the same `$` helpers as ordinary `cdata()` objects. Aggregate return callbacks
+must return a raw-backed object of the exact registered type.
+
+```{r aggregate-callback-return}
+make_point <- ccallback("dd)<Point>", function(x, y) {
+    out <- cdata(Point)
+    out$x <- x
+    out$y <- y
+    out
+})
+
+returned <- dyncall(make_point, "dd)<Point>", 4.5, 5.25)
+c(returned$x, returned$y)
+```
+
 ## Immediate and stored callbacks
 
 Callback lifetime depends on whether C calls the pointer during the current
@@ -120,7 +155,10 @@ function errors.
 - Do not let C call a callback after its R state has been cleaned up.
 - Avoid throwing errors through foreign event loops. Handle errors inside the
   callback and return a C-level failure value when the API supports one.
-- Aggregate by-value callback arguments and returns are not currently supported.
+- For aggregate callback returns, return a raw-backed `struct` object of the
+  exact expected type and size. A mismatch disables the callback.
+- Aggregate callbacks require an implemented 64-bit x86 or ARM64 dyncallback
+  backend; unsupported platforms fail when the callback is created.
 
 ## A safe registration pattern
 

--- a/vignettes/articles/signatures.Rmd
+++ b/vignettes/articles/signatures.Rmd
@@ -37,6 +37,7 @@ Type signatures describe individual C values. The most common ones are:
 
 Pointer types are written with `*`, such as `*i` for `int *`.
 Typed aggregate pointers are written as `*<TypeName>`.
+Registered aggregate values passed by value are written as `<TypeName>`.
 
 ## Call signatures
 
@@ -69,6 +70,7 @@ articles and demos.
 | `size_t strlen(const char *s);` | `strlen(Z)L` | `Z` passes a C string |
 | `void R_rsort(double *x, int n);` | `R_rsort(pi)v` | pointer to mutable `double` data |
 | `void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *));` | `qsort(pLLp)v` | callback has signature `pp)i` |
+| `int visit(Point p);` | callback signature `<Point>)i` | `Point` is passed by value |
 | `const char *SDL_GetPlatform(void);` | `SDL_GetPlatform()Z` | no arguments, C string return |
 
 The following example calls C's `strlen`, declared as:


### PR DESCRIPTION
## Summary

Add aggregate by-value support to `ccallback()` for the implemented 64-bit x86 and ARM64 dyncallback backends.

## Changes

- Translate callback `<Type>` signatures to dyncallback aggregate descriptors and pass raw-backed `struct` objects to R callbacks.
- Validate aggregate callback return values before returning them through `dcbReturnAggr()`.
- Implement ARM64 dyncallback aggregate argument and return helpers, including HFA, stack fallback, and hidden return paths.
- Extend aggregate callback tests, native ARM64 aggregate workflow coverage, and callback documentation.
