### PR TITLE
fix: isolate dynport parsing from attached packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 - Improve generated DynPort packages with argument-preserving wrappers,
   variadic function metadata, generated help pages and a cleanup helper for
   the managed DynPort library (#52).
+- Keep DynPort parsing isolated from already attached generated packages so
+  rebuilding or rerunning a generated package in the same R session remains
+  repeatable (#55).
 - Support `Constant` and `Variadic` fields in DCF DynPort files, including
   binding variadic entries through `dyncall_variadic()` (#53).
 - Add `dyncall_variadic()` for calling C variadic functions with explicit

--- a/R/dynport.R
+++ b/R/dynport.R
@@ -132,7 +132,7 @@ dynport <- function(portname, portfile = NULL, repo = system.file("dynports", pa
 }
 
 # ref: {r-lib/desc:::read_dcf()}
-dynport_read <- function(file) {
+dynport_read <- function(file, envir = dynport_parse_env()) {
     tryCatch(
         lines <- readLines(file),
         error = function(e) {
@@ -194,7 +194,11 @@ dynport_read <- function(file) {
         stop("Both 'Enum' and 'Enum/...' found. Should have either one.", call. = FALSE)
     }
 
-    dynport_parse_fields(keys, values, lnums, envir = parent.frame(2L))
+    dynport_parse_fields(keys, values, lnums, envir = envir)
+}
+
+dynport_parse_env <- function() {
+    new.env(parent = emptyenv())
 }
 
 dynport_parse_fields <- function(keys, values, lnums, envir = parent.frame()) {
@@ -472,7 +476,7 @@ dynport_parse_function <- function(value, lnum = 1L, envir = parent.frame()) {
             }
         }
 
-        ret <- dynport_parse_types("struct", ret_nm[[1L]], allow_arrays = FALSE)
+        ret <- dynport_parse_types("struct", ret_nm[[1L]], envir, allow_arrays = FALSE)
         dynport_issue_type_error(ret, ret_nm[[1L]], issue_error, name, "return")
 
         lnum <- lnum + lncnt[[i]]

--- a/inst/tinytest/test_dynport.R
+++ b/inst/tinytest/test_dynport.R
@@ -59,6 +59,23 @@ expect_dynport_portfile_error("Enum: a = 1", "Invalid specification")
 expect_dynport_portfile_error("Enum/test: a = 1 b = 2", "member specification")
 expect_dynport_portfile_error("Enum/test: a = 1.2", "member value")
 
+local({
+    search_name <- "package:rdyncallDynportCollision"
+    attach(list(DynportCollisionEnum = c(DYNPORT_COLLISION_ONE = 1L)), name = search_name)
+    on.exit(detach(search_name, character.only = TRUE), add = TRUE)
+
+    port <- rdyncall:::dynport_read(write_dynport(c(
+        "Package: CollisionPort",
+        "Version: 1.0.0",
+        "Function:",
+        "    missing_collision()<DynportCollisionEnum>;",
+        "Enum/DynportCollisionEnum:",
+        "    DYNPORT_COLLISION_ONE=1"
+    )))
+    expect_equal(port$Function$missing_collision$return, "<DynportCollisionEnum>")
+    expect_equal(port$Enum$DynportCollisionEnum, c(DYNPORT_COLLISION_ONE = 1L))
+})
+
 # struct
 expect_dynport_portfile_error(c("Struct: test", " }"), "\\{")
 expect_dynport_portfile_error(c("Struct: test{", " }}"), "\\}")
@@ -301,6 +318,31 @@ local({
         "rebuild = TRUE"
     )
     expect_silent(dynport_install_package(rebuild, portfile = portfile, lib = lib, rebuild = TRUE, quiet = TRUE))
+})
+
+local({
+    if (!is.null(dynfind(libc_names))) {
+        portfile <- write_dynport(c(
+            "Package: RerunEnumPort",
+            "Version: 1.0.0",
+            "Library:",
+            "    msvcrt",
+            "    c",
+            "    c.so.6",
+            "Function:",
+            "    missing_rerun_enum()<RerunEnum>;",
+            "Enum/RerunEnum:",
+            "    RERUN_ENUM_ONE=1"
+        ))
+        lib <- tempfile("rdyncall-dynport-lib")
+        package <- "RerunEnumPort"
+        unload_test_package(package)
+        on.exit(unload_test_package(package), add = TRUE)
+
+        expect_silent(dynport(rerun, portfile = portfile, package = package, lib = lib, rebuild = TRUE, quiet = TRUE))
+        expect_true(paste0("package:", package) %in% search())
+        expect_silent(dynport(rerun, portfile = portfile, package = package, lib = lib, rebuild = TRUE, quiet = TRUE))
+    }
 })
 
 local({


### PR DESCRIPTION
## Summary

Fix DynPort parsing so rerunning or rebuilding a generated package in the same R session does not see objects exported by the already attached generated package.

## Changes

- Parse DynPort files in an isolated environment and use that environment for function return type parsing.
- Add regression coverage for attached enum-name collisions and repeated generated package loads.
- Note the repeatable generated-package rebuild fix in NEWS.