### PR TITLE
fix: preserve known union storage sizes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@
   they can be reused for field access and aggregate by-value calls (#33).
 - Fix `cstruct()` and `cunion()` field parsing when whitespace follows the type signature (#21).
 - Store aggregate field names in the explicit `typeinfo$fields$name` column (#21).
+- Fix DynPort union size calculation when known storage fields appear alongside
+  opaque members, allowing `SDL_Event` values to be allocated from the generated
+  SDL3 binding.
 - Add dedicated print methods for `typeinfo`, `struct`, `ctype`,
   `dynbind.report` and `floatraw` objects (#41).
 - Add `callback_status()`, `callback_is_active()` and `callback_last_error()`

--- a/R/struct.R
+++ b/R/struct.R
@@ -415,6 +415,8 @@ parse_aggregate_types <- function(kind = c("struct", "union"), signature,
     array_lens <- integer()
     max_size <- 0L
     max_align <- 1L
+    has_known_union_field <- FALSE
+    has_unknown_union_field <- FALSE
 
     if (kind == "struct") {
         offset <- 0L
@@ -464,8 +466,14 @@ parse_aggregate_types <- function(kind = c("struct", "union"), signature,
             offsets <- c(offsets, offset)
             offset <- offset + field_size
         } else {
-            max_align <- max(max_align, aggregate_member_alignment(info$align, layout))
-            max_size <- max(max_size, field_size)
+            alignment <- aggregate_member_alignment(info$align, layout)
+            if (is.na(field_size) || is.na(alignment)) {
+                has_unknown_union_field <- TRUE
+            } else {
+                has_known_union_field <- TRUE
+                max_align <- max(max_align, alignment)
+                max_size <- max(max_size, field_size)
+            }
         }
     }
 
@@ -473,8 +481,13 @@ parse_aggregate_types <- function(kind = c("struct", "union"), signature,
         max_align <- aggregate_final_alignment(max_align, layout)
         size <- align(offset, max_align)
     } else {
-        max_align <- aggregate_final_alignment(max_align, layout)
-        size <- align(max_size, max_align)
+        if (!has_known_union_field && has_unknown_union_field) {
+            max_align <- NA_integer_
+            size <- NA_integer_
+        } else {
+            max_align <- aggregate_final_alignment(max_align, layout)
+            size <- align(max_size, max_align)
+        }
         offsets <- rep(0L, length(types))
     }
 

--- a/inst/tinytest/test_dynport.R
+++ b/inst/tinytest/test_dynport.R
@@ -191,6 +191,16 @@ expect_equal(sdl3$Constant$SDL_INIT_VIDEO, 32L)
 expect_true("SDL_GetPlatform" %in% names(sdl3$Function))
 expect_true(sdl3$Function$SDL_Log$variadic)
 expect_true("SDL_FRect" %in% names(sdl3$Struct))
+expect_true("SDL_Event" %in% names(sdl3$Union))
+expect_equal(sdl3$Union$SDL_Event$size, 128L)
+expect_equal(sdl3$Union$SDL_Event$align, 4L)
+expect_equal(
+    sdl3$Union$SDL_Event$fields$array_len[
+        sdl3$Union$SDL_Event$fields$name == "padding"
+    ],
+    128L
+)
+expect_equal(length(cdata(sdl3$Union$SDL_Event)), 128L)
 expect_equal(
     length(rdyncall:::dynport_wrapper_formals(
         rdyncall:::dynport_function_arg_names(sdl3$Function$SDL_GetNumAllocations)


### PR DESCRIPTION
## Summary

Fix DynPort union layout so known storage members still determine a usable union size when other members are opaque or otherwise unresolved.

## Changes

- Preserve known union member size and alignment while keeping all-unknown unions unknown.
- Add SDL3 `SDL_Event` regression coverage for `size = 128` and `cdata()` allocation.
- Document the fix in `NEWS.md`.
