### PR TITLE
docs: fix README callback notes and source package hygiene

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,6 +17,7 @@
 ^src/\.cache$
 ^tools/\.cache$
 ^tools/legacy-vignettes($|/)
+^inst/tinytest/.*\.(o|so|dll|dylib|a)$
 ^src/dyncall/dyncall/libdyncall_s\.a$
 ^src/dyncall/dyncallback/libdyncallback_s\.a$
 ^src/dyncall/dynload/libdynload_s\.a$

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,7 +2,7 @@
 output: github_document
 ---
 
-# rdyncall <img src="man/figures/logo.svg" align="right" height="138" />
+# rdyncall <img src="man/figures/logo.svg" alt="rdyncall logo" align="right" height="138" />
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/hongyuanjia/rdyncall/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/hongyuanjia/rdyncall/actions/workflows/R-CMD-check.yaml)
@@ -109,8 +109,8 @@ several layout features needed by real C APIs:
 - nested aggregate fields and by-value aggregate calls on supported DynCall
   backends.
 
-Callback signatures currently do not support aggregate by-value arguments or
-returns.
+For callbacks, `ccallback()` supports aggregate by-value arguments and returns
+on the implemented x86_64 and ARM64 dyncallback backends.
 
 ## DynPort Bindings
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# rdyncall <img src="man/figures/logo.svg" align="right" height="138" />
+# rdyncall <img src="man/figures/logo.svg" alt="rdyncall logo" align="right" height="138" />
 
 <!-- badges: start -->
 
@@ -114,8 +114,8 @@ supports several layout features needed by real C APIs:
 - nested aggregate fields and by-value aggregate calls on supported
   DynCall backends.
 
-Callback signatures currently do not support aggregate by-value
-arguments or returns.
+For callbacks, `ccallback()` supports aggregate by-value arguments and
+returns on the implemented x86_64 and ARM64 dyncallback backends.
 
 ## DynPort Bindings
 


### PR DESCRIPTION
## Summary

Fix README documentation that still described aggregate by-value callback support as unavailable, and keep README logo markup accessible.

## Changes

- Document that `ccallback()` supports aggregate by-value arguments and returns on the implemented x86_64 and ARM64 dyncallback backends.
- Add `alt` text to the README logo and regenerate `README.md` from `README.Rmd`.
- Exclude local `inst/tinytest` binary build artifacts from source package builds while keeping the C fixtures and R tests included.
