### PR TITLE
fix: harden low-level argument validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,8 @@
 - Add `struct` and `union` bitfield layout, access, DynPort parsing, and by-value aggregate support (#26).
 - Add the `rdyncall.callvm.size` option to configure CallVM argument stack size at package load (#22).
 - Add by-value aggregate argument and return support to `dyncall()` for registered `struct` and `union` types on supported dyncall backends, including ARM64 aggregate ABI handling (#23).
+- Harden low-level argument validation for typed pointer signatures, packing
+  helpers and pointer offsets (#59).
 - Support fixed-size array fields in `struct` and `union` type signatures via the `type[N]` suffix (#26).
 - Add `@packed`, `@pack(n)` and `@align(n)` layout directives for `cstruct()`, `cunion()` and DynPort aggregate definitions (#26).
 - Refresh roxygen-generated documentation and package metadata for renewed development (#19).

--- a/R/dyncall.R
+++ b/R/dyncall.R
@@ -352,7 +352,7 @@ dyncall_variadic_signature <- function(signature, varargs) {
 #' | '`Z`'                    | char*               | character,NULL              | character or NULL |
 #' | '`x`'                    | SEXP                | any                         | any               |
 #' | '`v`'                    | void                | invalid                     | NULL              |
-#' | '`*`' ...                | C type* (pointer)   | any vector,externalptr,NULL | externalptr       |
+#' | '`*`' ...                | C type* (pointer)   | compatible vector,externalptr,NULL | externalptr       |
 #' | '`*<`' _typename_ '`>`'  | typename* (pointer) | raw,externalptr             | externalptr       |
 #' | '`<`' _typename_ '`>`'   | typename (by value) | raw `struct` from [cdata()] | raw `struct`      |
 #'
@@ -365,6 +365,11 @@ dyncall_variadic_signature <- function(signature, varargs) {
 #' The last typed pointer rows of the table above refer to _typed pointer_ signatures.
 #' If they appear as a return type signature, the external pointer returned is a
 #' S3 `struct` object. See [cdata()] for details.
+#' Low-level typed pointer signatures accept `NULL` and external pointers for
+#' all base pointer types. Vector-backed convenience arguments are available
+#' when the R vector storage matches the C pointee type, for example integer
+#' for `*i`/`*I`, numeric for `*d`, `floatraw` for `*f`, character/raw for
+#' `*c`/`*C`, and general vectors for `*v`.
 #'
 #'
 #' # Call Signature

--- a/R/pack.R
+++ b/R/pack.R
@@ -14,12 +14,13 @@
 #' object `x` and converts the C value to an R value and returns it.
 #'
 #' Byte `offset` calculations start at 0 relative to the first byte in an atomic
-#' vectors data area.
+#' vectors data area. Offsets must be non-missing, non-negative integer scalars.
 #'
 #' If `x` is an atomic vector, a bound check is carried out before read/write
 #' access.
 #' Otherwise, if `x` is an external pointer, there is only a C NULL pointer
 #' check.
+#' Values read from R vectors must have length greater than zero.
 #'
 #' @param x atomic vector (logical, raw, integer or double) or external pointer.
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,7 +11,7 @@
 #' `as.externalptr()` returns an external pointer to the data area of atomic
 #' vector given by `x`.
 #' The external pointer holds an additional reference to the `x` R object to
-#' prevent it from garbage collection.
+#' prevent it from garbage collection. `x` must have length greater than zero.
 #'
 #' `is.externalptr()` tests if the object given by `x` is an external pointer.
 #'
@@ -31,10 +31,11 @@
 #' `ptr2str()`, `strarrayptr()`, `strptr()` are currently experimental.
 #'
 #' `offset_ptr()` creates a new external pointer pointing to `x` plus
-#' the byte `offset`.
+#' the non-negative byte `offset`.
 #' If `x` is given as an external pointer, the address is increased by the
 #' `offset`, or, if `x` is given as a atomic vector, the address of the data
 #' (pointing to offset zero) is taken as basis and increased by the `offset`.
+#' Atomic vector offsets are checked against the vector byte size.
 #' The returned external pointer is protected (as offered by the C function `R_MakeExternalPtr`) by the
 #' external pointer `x`.
 #'

--- a/inst/tinytest/argument_safeguards.c
+++ b/inst/tinytest/argument_safeguards.c
@@ -1,0 +1,41 @@
+#include <stddef.h>
+
+int rdyncall_arg_ptr_is_null(void *p)
+{
+  return p == NULL;
+}
+
+int rdyncall_arg_ptr_is_nonnull(void *p)
+{
+  return p != NULL;
+}
+
+int rdyncall_arg_int_ptr_value(int *p)
+{
+  return p == NULL ? -1 : *p;
+}
+
+int rdyncall_arg_double_ptr_nonnull(double *p)
+{
+  return p != NULL;
+}
+
+int rdyncall_arg_float_ptr_nonnull(float *p)
+{
+  return p != NULL;
+}
+
+int rdyncall_arg_char_ptr_nonnull(char *p)
+{
+  return p != NULL;
+}
+
+int rdyncall_arg_short_ptr_nonnull(short *p)
+{
+  return p != NULL;
+}
+
+int rdyncall_arg_ptrptr_nonnull(void **p)
+{
+  return p != NULL;
+}

--- a/inst/tinytest/test_arg_safeguards.R
+++ b/inst/tinytest/test_arg_safeguards.R
@@ -1,0 +1,72 @@
+build_argument_safeguards_fixture <- function() {
+    src <- system.file("tinytest", "argument_safeguards.c", package = "rdyncall", mustWork = TRUE)
+    src <- normalizePath(src, winslash = "/", mustWork = TRUE)
+    outdir <- tempfile("rdyncall-argument-safeguards-")
+    dir.create(outdir)
+    outdir <- normalizePath(outdir, winslash = "/", mustWork = TRUE)
+    lib <- file.path(outdir, paste0("argument_safeguards", .Platform$dynlib.ext))
+    out <- system2(file.path(R.home("bin"), "R"),
+        c("CMD", "SHLIB", "-o", lib, src),
+        stdout = TRUE, stderr = TRUE
+    )
+    if (!is.null(attr(out, "status"))) {
+        stop(paste(c("failed to build argument safeguard test fixture", out), collapse = "\n"), call. = FALSE)
+    }
+    dynload(lib)
+}
+
+arg_fixture <- build_argument_safeguards_fixture()
+arg_sym <- function(name) dynsym(arg_fixture, name)
+
+ptr_is_null <- arg_sym("rdyncall_arg_ptr_is_null")
+ptr_is_nonnull <- arg_sym("rdyncall_arg_ptr_is_nonnull")
+int_ptr_value <- arg_sym("rdyncall_arg_int_ptr_value")
+double_ptr_nonnull <- arg_sym("rdyncall_arg_double_ptr_nonnull")
+float_ptr_nonnull <- arg_sym("rdyncall_arg_float_ptr_nonnull")
+char_ptr_nonnull <- arg_sym("rdyncall_arg_char_ptr_nonnull")
+short_ptr_nonnull <- arg_sym("rdyncall_arg_short_ptr_nonnull")
+ptrptr_nonnull <- arg_sym("rdyncall_arg_ptrptr_nonnull")
+
+expect_equal(dyncall(ptr_is_null, "*s)i", NULL), 1L)
+expect_equal(dyncall(short_ptr_nonnull, "*s)i", as.externalptr(raw(2))), 1L)
+expect_error(dyncall(short_ptr_nonnull, "*s)i", integer(1)), "external pointer")
+
+expect_equal(dyncall(int_ptr_value, "*i)i", 42L), 42L)
+expect_equal(dyncall(int_ptr_value, "*i)i", as.externalptr(42L)), 42L)
+expect_error(dyncall(int_ptr_value, "*i)i", numeric(1)), "integer")
+
+expect_equal(dyncall(double_ptr_nonnull, "*d)i", 1.25), 1L)
+expect_error(dyncall(double_ptr_nonnull, "*d)i", 1L), "numeric")
+
+floats <- as.floatraw(1.5)
+expect_equal(dyncall(float_ptr_nonnull, "*f)i", floats), 1L)
+expect_equal(dyncall(float_ptr_nonnull, "*f)i", as.externalptr(floats)), 1L)
+expect_error(dyncall(float_ptr_nonnull, "*f)i", raw(4)), "floatraw")
+
+expect_equal(dyncall(ptr_is_nonnull, "*v)i", raw(1)), 1L)
+expect_error(dyncall(ptr_is_nonnull, "*v)i", raw()), "length greater zero")
+expect_equal(dyncall(char_ptr_nonnull, "*c)i", raw(1)), 1L)
+expect_error(dyncall(char_ptr_nonnull, "**c)i", raw(1)), "external pointer")
+expect_equal(dyncall(ptrptr_nonnull, "**c)i", as.externalptr(raw(.Machine$sizeof.pointer))), 1L)
+
+cstruct("ArgBox{i} value;")
+arg_box <- cdata(ArgBox)
+expect_equal(dyncall(ptr_is_nonnull, "*<ArgBox>)i", arg_box), 1L)
+expect_error(dyncall(ptr_is_nonnull, "*<ArgBox>)i", raw(ArgBox$size)), "struct metadata")
+
+buf <- raw(8)
+expect_error(pack(buf, -1L, "i", 1L), "offset")
+expect_error(pack(buf, NA_integer_, "i", 1L), "offset")
+expect_error(pack(buf, 8L, "i", 1L), "out-of-bounds")
+expect_error(pack(buf, 0L, "i", integer()), "length greater zero")
+expect_error(pack(buf, 0L, "", 1L), "sigchar")
+
+expect_error(unpack(buf, -1L, "i"), "offset")
+expect_error(unpack(buf, 8L, "i"), "out-of-bounds")
+expect_error(unpack(buf, 0L, ""), "sigchar")
+
+expect_error(as.externalptr(raw()), "length greater zero")
+expect_error(offset_ptr(raw(4), -1L), "offset")
+expect_error(offset_ptr(raw(4), NA_integer_), "offset")
+expect_error(offset_ptr(raw(4), 5L), "out-of-bounds")
+expect_true(is.externalptr(offset_ptr(raw(4), 4L)))

--- a/man/dyncall.Rd
+++ b/man/dyncall.Rd
@@ -156,7 +156,7 @@ types.\tabular{llll}{
    '\code{Z}' \tab char* \tab character,NULL \tab character or NULL \cr
    '\code{x}' \tab SEXP \tab any \tab any \cr
    '\code{v}' \tab void \tab invalid \tab NULL \cr
-   '\code{*}' ... \tab C type* (pointer) \tab any vector,externalptr,NULL \tab externalptr \cr
+   '\code{*}' ... \tab C type* (pointer) \tab compatible vector,externalptr,NULL \tab externalptr \cr
    '\verb{*<}' \emph{typename} '\code{>}' \tab typename* (pointer) \tab raw,externalptr \tab externalptr \cr
    '\code{<}' \emph{typename} '\code{>}' \tab typename (by value) \tab raw \code{struct} from \code{\link[=cdata]{cdata()}} \tab raw \code{struct} \cr
 }
@@ -171,6 +171,11 @@ registered typeinfo.
 The last typed pointer rows of the table above refer to \emph{typed pointer} signatures.
 If they appear as a return type signature, the external pointer returned is a
 S3 \code{struct} object. See \code{\link[=cdata]{cdata()}} for details.
+Low-level typed pointer signatures accept \code{NULL} and external pointers for
+all base pointer types. Vector-backed convenience arguments are available
+when the R vector storage matches the C pointee type, for example integer
+for \verb{*i}/\verb{*I}, numeric for \verb{*d}, \code{floatraw} for \verb{*f}, character/raw for
+\verb{*c}/\verb{*C}, and general vectors for \verb{*v}.
 }
 
 \section{Call Signature}{

--- a/man/packing.Rd
+++ b/man/packing.Rd
@@ -36,12 +36,13 @@ The function \code{unpack()} extracts a C data type according to the
 object \code{x} and converts the C value to an R value and returns it.
 
 Byte \code{offset} calculations start at 0 relative to the first byte in an atomic
-vectors data area.
+vectors data area. Offsets must be non-missing, non-negative integer scalars.
 
 If \code{x} is an atomic vector, a bound check is carried out before read/write
 access.
 Otherwise, if \code{x} is an external pointer, there is only a C NULL pointer
 check.
+Values read from R vectors must have length greater than zero.
 }
 \examples{
 # transfer double to array of floats and back, compare precision:

--- a/man/utils.Rd
+++ b/man/utils.Rd
@@ -64,7 +64,7 @@ and objects to handle C \code{float} arrays and strings.
 \code{as.externalptr()} returns an external pointer to the data area of atomic
 vector given by \code{x}.
 The external pointer holds an additional reference to the \code{x} R object to
-prevent it from garbage collection.
+prevent it from garbage collection. \code{x} must have length greater than zero.
 
 \code{is.externalptr()} tests if the object given by \code{x} is an external pointer.
 
@@ -84,10 +84,11 @@ This function is useful when calling foreign functions that expect a C
 \code{ptr2str()}, \code{strarrayptr()}, \code{strptr()} are currently experimental.
 
 \code{offset_ptr()} creates a new external pointer pointing to \code{x} plus
-the byte \code{offset}.
+the non-negative byte \code{offset}.
 If \code{x} is given as an external pointer, the address is increased by the
 \code{offset}, or, if \code{x} is given as a atomic vector, the address of the data
 (pointing to offset zero) is taken as basis and increased by the \code{offset}.
+Atomic vector offsets are checked against the vector byte size.
 The returned external pointer is protected (as offered by the C function \code{R_MakeExternalPtr}) by the
 external pointer \code{x}.
 }

--- a/src/rdyncall.c
+++ b/src/rdyncall.c
@@ -250,6 +250,114 @@ static void rdyncall_set_struct_attrib(SEXP x, const char *name)
   Rf_setAttrib(x, R_ClassSymbol, Rf_mkString("struct"));
 }
 
+static int rdyncall_has_class(SEXP x, const char *class_name)
+{
+  SEXP classes = Rf_getAttrib(x, R_ClassSymbol);
+  if (TYPEOF(classes) != STRSXP) return 0;
+
+  for (R_xlen_t i = 0; i < XLENGTH(classes); i++) {
+    SEXP cls = STRING_ELT(classes, i);
+    if (cls != NA_STRING && strcmp(CHAR(cls), class_name) == 0) return 1;
+  }
+
+  return 0;
+}
+
+static const char* rdyncall_struct_attr(SEXP x, int argpos)
+{
+  SEXP structName = Rf_getAttrib(x, Rf_install("struct"));
+  if (TYPEOF(structName) != STRSXP || XLENGTH(structName) < 1 ||
+      STRING_ELT(structName, 0) == NA_STRING) {
+    Rf_error("Argument type mismatch at position %d: expected struct metadata on typed pointer argument", argpos);
+  }
+
+  return CHAR(STRING_ELT(structName, 0));
+}
+
+static void rdyncall_expect_nonempty_vector_arg(SEXP arg, int argpos)
+{
+  switch(TYPEOF(arg)) {
+    case LGLSXP:
+    case INTSXP:
+    case REALSXP:
+    case CPLXSXP:
+    case RAWSXP:
+    case STRSXP:
+      if (XLENGTH(arg) == 0) {
+        Rf_error("Argument type mismatch at position %d: expected length greater zero.", argpos);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+static DCpointer rdyncall_lowlevel_pointer_arg(SEXP arg, char ch, int ptrcnt, int argpos)
+{
+  int type_id = TYPEOF(arg);
+
+  if (type_id == NILSXP) return (DCpointer) 0;
+  if (type_id == EXTPTRSXP) return R_ExternalPtrAddr(arg);
+  if (ptrcnt > 1) {
+    Rf_error("Argument type mismatch at position %d: expected NULL or external pointer for multi-level typed pointer", argpos);
+  }
+
+  rdyncall_expect_nonempty_vector_arg(arg, argpos);
+
+  switch(ch) {
+    case DC_SIGCHAR_VOID:
+      switch(type_id)
+      {
+        case STRSXP:  return (DCpointer) CHAR(STRING_ELT(arg, 0));
+        case LGLSXP:  return (DCpointer) LOGICAL(arg);
+        case INTSXP:  return (DCpointer) INTEGER(arg);
+        case REALSXP: return (DCpointer) REAL(arg);
+        case CPLXSXP: return (DCpointer) COMPLEX(arg);
+        case RAWSXP:  return (DCpointer) RAW(arg);
+        default:
+          Rf_error("Argument type mismatch at position %d: expected pointer convertable value", argpos);
+      }
+      break;
+    case DC_SIGCHAR_CHAR:
+    case DC_SIGCHAR_UCHAR:
+      switch(type_id)
+      {
+        case STRSXP: return (DCpointer) CHAR(STRING_ELT(arg, 0));
+        case RAWSXP: return (DCpointer) RAW(arg);
+        default:
+          Rf_error("Argument type mismatch at position %d: expected character, raw, external pointer, or NULL for C character pointer", argpos);
+      }
+      break;
+    case DC_SIGCHAR_INT:
+    case DC_SIGCHAR_UINT:
+      if (type_id == INTSXP) return (DCpointer) INTEGER(arg);
+      Rf_error("Argument type mismatch at position %d: expected integer, external pointer, or NULL for C integer pointer", argpos);
+      break;
+    case DC_SIGCHAR_DOUBLE:
+      if (type_id == REALSXP) return (DCpointer) REAL(arg);
+      Rf_error("Argument type mismatch at position %d: expected numeric, external pointer, or NULL for C double pointer", argpos);
+      break;
+    case DC_SIGCHAR_FLOAT:
+      if (type_id == RAWSXP && rdyncall_has_class(arg, "floatraw")) return (DCpointer) RAW(arg);
+      Rf_error("Argument type mismatch at position %d: expected floatraw, external pointer, or NULL for C float pointer", argpos);
+      break;
+    case DC_SIGCHAR_SHORT:
+    case DC_SIGCHAR_USHORT:
+    case DC_SIGCHAR_LONG:
+    case DC_SIGCHAR_ULONG:
+    case DC_SIGCHAR_LONGLONG:
+    case DC_SIGCHAR_ULONGLONG:
+    case DC_SIGCHAR_POINTER:
+    case DC_SIGCHAR_STRING:
+      Rf_error("Argument type mismatch at position %d: expected external pointer or NULL for this typed pointer signature", argpos);
+      break;
+    default:
+      Rf_error("Unsupported typed pointer signature at position %d", argpos);
+  }
+
+  return (DCpointer) 0;
+}
+
 static int rdyncall_mode_from_signature_char(char ch)
 {
   switch(ch)
@@ -419,10 +527,7 @@ SEXP C_dyncall(SEXP args) /* callvm, address, signature, aggregate layouts, args
         continue;
       }
 
-      if ( type_id != NILSXP && type_id != EXTPTRSXP && LENGTH(arg) == 0 ) {
-        Rf_error("Argument type mismatch at position %d: expected length greater zero.", argpos);
-        /* dummy */ return R_NilValue;
-      }
+      if (type_id != NILSXP && type_id != EXTPTRSXP) rdyncall_expect_nonempty_vector_arg(arg, argpos);
       switch(ch) {
         case DC_SIGCHAR_BOOL:
         {
@@ -660,14 +765,9 @@ SEXP C_dyncall(SEXP args) /* callvm, address, signature, aggregate layouts, args
         sig++;
         /* check pointer type */
         if (type_id != NILSXP) {
-          SEXP structName = Rf_getAttrib(arg, Rf_install("struct"));
-          if (structName == R_NilValue) {
-            Rf_error("typed pointer needed here");
-            return R_NilValue; /* Dummy */
-          }
+          n = rdyncall_struct_attr(arg, argpos);
           e = sig-1;
           l = e - b;
-          n = CHAR(STRING_ELT(structName,0));
           if ( (strlen(n) != l) || (strncmp(b,n,l) != 0) ) {
             Rf_error("incompatible pointer types");
             return R_NilValue; /* Dummy */
@@ -683,110 +783,7 @@ SEXP C_dyncall(SEXP args) /* callvm, address, signature, aggregate layouts, args
         dcArgPointer(pvm, ptrValue);
         ptrcnt = 0;
       } else { /* typed low-level pointers */
-        switch(ch) {
-          case DC_SIGCHAR_VOID:
-            switch(type_id)
-            {
-              case NILSXP:    ptrValue = (DCpointer) 0; break;
-              case STRSXP:    ptrValue = (DCpointer) CHAR(STRING_ELT(arg,0)); break;
-              case LGLSXP:    ptrValue = (DCpointer) LOGICAL(arg); break;
-              case INTSXP:    ptrValue = (DCpointer) INTEGER(arg); break;
-              case REALSXP:   ptrValue = (DCpointer) REAL(arg); break;
-              case CPLXSXP:   ptrValue = (DCpointer) COMPLEX(arg); break;
-              case RAWSXP:    ptrValue = (DCpointer) RAW(arg); break;
-              case EXTPTRSXP: ptrValue = R_ExternalPtrAddr(arg); break;
-              default:        Rf_error("Argument type mismatch at position %d: expected pointer convertable value", argpos);
-                return R_NilValue; /* dummy */
-            }
-            break;
-          case DC_SIGCHAR_CHAR:
-          case DC_SIGCHAR_UCHAR:
-            switch(type_id)
-            {
-              case NILSXP:    ptrValue = (DCpointer) 0; break;
-              case STRSXP:
-                if (ptrcnt == 1) {
-                  ptrValue = (DCpointer) CHAR( STRING_ELT(arg,0) );
-                } else {
-                  Rf_error("Argument type mismatch at position %d: expected 'C string' convertable value", argpos);
-                  return R_NilValue; /* dummy */
-                }
-                break;
-              case RAWSXP:
-                if (ptrcnt == 1) {
-                  ptrValue = RAW(arg);
-                } else {
-                  Rf_error("Argument type mismatch at position %d: expected 'C string' convertable value", argpos);
-                  return R_NilValue; /* dummy */
-                }
-                break;
-              case EXTPTRSXP: ptrValue = R_ExternalPtrAddr(arg); break;
-              default:
-                Rf_error("Argument type mismatch at position %d: expected 'C string' convertable value", argpos);
-                return R_NilValue; /* dummy */
-            }
-            break;
-          case DC_SIGCHAR_USHORT:
-          case DC_SIGCHAR_SHORT:
-              Rf_error("Signature '*[sS]' not implemented");
-              return R_NilValue; /* dummy */
-          case DC_SIGCHAR_UINT:
-          case DC_SIGCHAR_INT:
-            switch(type_id)
-            {
-              case NILSXP:  ptrValue = (DCpointer) 0; break;
-              case INTSXP:  ptrValue = (DCpointer) INTEGER(arg); break;
-              default:      Rf_error("Argument type mismatch at position %d: expected 'pointer to C integer' convertable value", argpos);
-                return R_NilValue; /* dummy */
-            }
-            break;
-          case DC_SIGCHAR_ULONG:
-          case DC_SIGCHAR_LONG:
-              Rf_error("Signature '*[jJ]' not implemented");
-              return R_NilValue; /* dummy */
-          case DC_SIGCHAR_ULONGLONG:
-          case DC_SIGCHAR_LONGLONG:
-              Rf_error("Signature '*[lJ]' not implemented");
-              return R_NilValue; /* dummy */
-          case DC_SIGCHAR_FLOAT:
-            switch(type_id)
-            {
-              case NILSXP:  ptrValue = (DCpointer) 0; break;
-              case RAWSXP:
-                if ( strcmp( CHAR(STRING_ELT(Rf_getAttrib(arg, Rf_install("class")),0)),"floatraw") == 0 ) {
-                  ptrValue = (DCpointer) RAW(arg);
-                } else {
-                  Rf_error("Argument type mismatch at position %d: expected 'pointer to C double' convertable value", argpos);
-                  return R_NilValue; /* dummy */
-                }
-                break;
-              default:      Rf_error("Argument type mismatch at position %d: expected 'pointer to C double' convertable value", argpos);
-                return R_NilValue; /* dummy */
-            }
-            break;
-          case DC_SIGCHAR_DOUBLE:
-            switch(type_id)
-            {
-              case NILSXP:  ptrValue = (DCpointer) 0; break;
-              case REALSXP: ptrValue = (DCpointer) REAL(arg); break;
-              default:      Rf_error("Argument type mismatch at position %d: expected 'pointer to C double' convertable value", argpos);
-                return R_NilValue; /* dummy */
-            }
-            break;
-          case DC_SIGCHAR_POINTER:
-          case DC_SIGCHAR_STRING:
-            switch(type_id)
-            {
-              case EXTPTRSXP:
-                ptrValue = R_ExternalPtrAddr( arg ); break;
-              default: Rf_error("low-level typed pointer on pointer not implemented");
-                return R_NilValue; /* dummy */
-            }
-            break;
-          default:
-            Rf_error("low-level typed pointer on C char pointer not implemented");
-            return R_NilValue; /* dummy */
-        }
+        ptrValue = rdyncall_lowlevel_pointer_arg(arg, ch, ptrcnt, argpos);
         dcArgPointer(pvm, ptrValue);
         ptrcnt = 0;
       }
@@ -862,8 +859,16 @@ SEXP C_dyncall(SEXP args) /* callvm, address, signature, aggregate layouts, args
           char buf[128];
           const char* begin = ++sig;
           const char* end   = strchr(sig, '>');
+          if (end == NULL) {
+            Rf_error("Invalid signature '%s' - missing '>' marker for aggregate pointer return.", signature);
+            return R_NilValue;
+          }
           size_t n = end - begin;
-          strncpy(buf, begin, n);
+          if (n == 0 || n >= sizeof(buf)) {
+            Rf_error("Invalid signature '%s' - aggregate pointer return type name is too long.", signature);
+            return R_NilValue;
+          }
+          memcpy(buf, begin, n);
           buf[n] = '\0';
           rdyncall_set_struct_attrib(ans, buf);
         } break;

--- a/src/rpack.c
+++ b/src/rpack.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stddef.h>
+#include <limits.h>
 #include "rdyncall_signature.h"
 /** ---------------------------------------------------------------------------
  ** C-Function: C_dataptr
@@ -17,20 +18,34 @@
  **
  **/
 
+static ptrdiff_t C_byte_size(R_xlen_t length, size_t element_size)
+{
+  if (element_size > 0 && length > (R_xlen_t) (PTRDIFF_MAX / (ptrdiff_t) element_size)) {
+    error("R object is too large for pointer offset arithmetic");
+  }
+  return (ptrdiff_t) length * (ptrdiff_t) element_size;
+}
+
 static char* C_dataptr_offset(SEXP x, ptrdiff_t o, size_t element_size)
 {
   char* p = NULL;
   ptrdiff_t s = 0;
-  
+
+  if (o < 0) error("offset must be a non-missing non-negative integer scalar");
+
   switch(TYPEOF(x))
   {
-    case CHARSXP:   p = (char*) CHAR(x);    s = LENGTH(x)*sizeof(char); break;
-    case LGLSXP:    p = (char*) LOGICAL(x); s = LENGTH(x)*sizeof(Rboolean); break;
-    case INTSXP:    p = (char*) INTEGER(x); s = LENGTH(x)*sizeof(int); break;
-    case REALSXP:   p = (char*) REAL(x);    s = LENGTH(x)*sizeof(double); break;
-    case CPLXSXP:   p = (char*) COMPLEX(x); s = LENGTH(x)*sizeof(Rcomplex); break; 
-    case STRSXP:    p = (char*) CHAR( STRING_ELT(x,0) ); s = strlen(p)*sizeof(char); break;
-    case RAWSXP:    p = (char*) RAW(x); s = LENGTH(x)*sizeof(char); break;
+    case CHARSXP:   p = (char*) CHAR(x);    s = (ptrdiff_t) strlen(p); break;
+    case LGLSXP:    p = (char*) LOGICAL(x); s = C_byte_size(XLENGTH(x), sizeof(Rboolean)); break;
+    case INTSXP:    p = (char*) INTEGER(x); s = C_byte_size(XLENGTH(x), sizeof(int)); break;
+    case REALSXP:   p = (char*) REAL(x);    s = C_byte_size(XLENGTH(x), sizeof(double)); break;
+    case CPLXSXP:   p = (char*) COMPLEX(x); s = C_byte_size(XLENGTH(x), sizeof(Rcomplex)); break;
+    case STRSXP:
+      if (XLENGTH(x) == 0) error("value must have length greater zero");
+      p = (char*) CHAR( STRING_ELT(x,0) );
+      s = (ptrdiff_t) strlen(p);
+      break;
+    case RAWSXP:    p = (char*) RAW(x); s = C_byte_size(XLENGTH(x), sizeof(char)); break;
     case EXTPTRSXP:
       p = (char*) R_ExternalPtrAddr(x);
       if (p == NULL) error("NULL address pointer");
@@ -38,14 +53,57 @@ static char* C_dataptr_offset(SEXP x, ptrdiff_t o, size_t element_size)
     default: error("invalid object type"); break;
   }
   if (p == NULL) error("NULL address pointer");
-  if (o < 0 || o+element_size > s) error("offset %td is out-of-bounds of the R object (max size %td)", o, s);
+  if (o > s || element_size > (size_t) (s - o)) error("offset %td is out-of-bounds of the R object (max size %td)", o, s);
   return p + o; 
+}
+
+static ptrdiff_t C_validate_offset(SEXP off)
+{
+  if (TYPEOF(off) != INTSXP || XLENGTH(off) < 1) error("offset must be a non-missing non-negative integer scalar");
+  int value = INTEGER(off)[0];
+  if (value == NA_INTEGER || value < 0) error("offset must be a non-missing non-negative integer scalar");
+  return (ptrdiff_t) value;
+}
+
+static int C_validate_int_scalar(SEXP x, const char *name)
+{
+  if (TYPEOF(x) != INTSXP || XLENGTH(x) < 1 || INTEGER(x)[0] == NA_INTEGER) {
+    error("%s must be a non-missing integer scalar", name);
+  }
+  return INTEGER(x)[0];
+}
+
+static const char* C_validate_sig(SEXP sig_x)
+{
+  if (TYPEOF(sig_x) != STRSXP || XLENGTH(sig_x) < 1 ||
+      STRING_ELT(sig_x, 0) == NA_STRING) {
+    error("sigchar must be a non-missing character scalar");
+  }
+  const char *sig = CHAR(STRING_ELT(sig_x, 0));
+  if (sig[0] == '\0') error("sigchar must not be empty");
+  return sig;
+}
+
+static void C_require_nonempty_vector(SEXP x, const char *name)
+{
+  switch(TYPEOF(x))
+  {
+    case LGLSXP:
+    case INTSXP:
+    case REALSXP:
+    case CPLXSXP:
+    case STRSXP:
+    case RAWSXP:
+      if (XLENGTH(x) == 0) error("%s must have length greater zero", name);
+      break;
+    default:
+      break;
+  }
 }
 
 static char* C_dataptr(SEXP x, SEXP off, size_t element_size)
 {
-  if ( LENGTH(off) == 0 ) error("missing offset");
-  return C_dataptr_offset(x, INTEGER(off)[0], element_size);
+  return C_dataptr_offset(x, C_validate_offset(off), element_size);
 }
 
 static void C_store(SEXP x, SEXP off, const void* value, size_t size)
@@ -113,6 +171,7 @@ static int C_bitfield_sig_is_signed(char sig)
 
 static uint64_t C_bitfield_value(SEXP value_x, int is_signed)
 {
+  C_require_nonempty_vector(value_x, "value");
   switch(TYPEOF(value_x))
   {
     case LGLSXP:
@@ -133,9 +192,12 @@ static uint64_t C_bitfield_value(SEXP value_x, int is_signed)
 
 SEXP C_unpack_bitfield(SEXP ptr_x, SEXP bit_offset_x, SEXP bit_width_x, SEXP sig_x)
 {
-  int bit_offset = INTEGER(bit_offset_x)[0];
-  int width = INTEGER(bit_width_x)[0];
-  const char sig = CHAR(STRING_ELT(sig_x, 0))[0];
+  int bit_offset = C_validate_int_scalar(bit_offset_x, "bit offset");
+  int width = C_validate_int_scalar(bit_width_x, "bit width");
+  const char sig = C_validate_sig(sig_x)[0];
+  if (bit_offset < 0) error("bit offset must be non-negative");
+  if (width < 1 || width > 64) error("bit width must be between 1 and 64");
+  if (bit_offset > INT_MAX - width - 7) error("bitfield range is too large");
   int byte_offset = bit_offset / 8;
   int intra_bit_offset = bit_offset % 8;
   size_t byte_count = (size_t) ((intra_bit_offset + width + 7) / 8);
@@ -181,9 +243,12 @@ SEXP C_unpack_bitfield(SEXP ptr_x, SEXP bit_offset_x, SEXP bit_width_x, SEXP sig
 
 SEXP C_pack_bitfield(SEXP ptr_x, SEXP bit_offset_x, SEXP bit_width_x, SEXP sig_x, SEXP value_x)
 {
-  int bit_offset = INTEGER(bit_offset_x)[0];
-  int width = INTEGER(bit_width_x)[0];
-  const char sig = CHAR(STRING_ELT(sig_x, 0))[0];
+  int bit_offset = C_validate_int_scalar(bit_offset_x, "bit offset");
+  int width = C_validate_int_scalar(bit_width_x, "bit width");
+  const char sig = C_validate_sig(sig_x)[0];
+  if (bit_offset < 0) error("bit offset must be non-negative");
+  if (width < 1 || width > 64) error("bit width must be between 1 and 64");
+  if (bit_offset > INT_MAX - width - 7) error("bitfield range is too large");
   int byte_offset = bit_offset / 8;
   int intra_bit_offset = bit_offset % 8;
   size_t byte_count = (size_t) ((intra_bit_offset + width + 7) / 8);
@@ -205,7 +270,8 @@ SEXP C_pack_bitfield(SEXP ptr_x, SEXP bit_offset_x, SEXP bit_width_x, SEXP sig_x
 SEXP C_pack(SEXP ptr_x, SEXP offset, SEXP sig_x, SEXP value_x)
 {
   int type_of = TYPEOF(value_x);
-  const char* sig = CHAR(STRING_ELT(sig_x,0) );
+  const char* sig = C_validate_sig(sig_x);
+  if (sig[0] != DC_SIGCHAR_SEXP) C_require_nonempty_vector(value_x, "value");
   switch(sig[0])
   {
     case DC_SIGCHAR_BOOL:
@@ -442,7 +508,7 @@ SEXP C_pack(SEXP ptr_x, SEXP offset, SEXP sig_x, SEXP value_x)
  **/
 SEXP C_unpack(SEXP ptr_x, SEXP offset, SEXP sig_x)
 {
-  const char* sig = CHAR(STRING_ELT(sig_x,0) );
+  const char* sig = C_validate_sig(sig_x);
   switch(sig[0])
   {
     case DC_SIGCHAR_BOOL: {

--- a/src/rutils.c
+++ b/src/rutils.c
@@ -6,6 +6,30 @@
 
 #include <Rinternals.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <limits.h>
+
+static ptrdiff_t R_vector_data_size(SEXP x)
+{
+  size_t element_size;
+
+  switch (TYPEOF(x)) {
+  case LGLSXP:  element_size = sizeof(Rboolean); break;
+  case INTSXP:  element_size = sizeof(int); break;
+  case REALSXP: element_size = sizeof(double); break;
+  case CPLXSXP: element_size = sizeof(Rcomplex); break;
+  case RAWSXP:  element_size = sizeof(Rbyte); break;
+  default:
+    error("unsupported vector type");
+    return 0; /* dummy */
+  }
+
+  if (element_size > 0 && XLENGTH(x) > (R_xlen_t) (PTRDIFF_MAX / (ptrdiff_t) element_size)) {
+    error("R object is too large for pointer offset arithmetic");
+  }
+
+  return (ptrdiff_t) XLENGTH(x) * (ptrdiff_t) element_size;
+}
 
 static void* R_vector_data_ptr(SEXP x)
 {
@@ -21,6 +45,18 @@ static void* R_vector_data_ptr(SEXP x)
   }
 }
 
+static ptrdiff_t C_validate_offset(SEXP offset)
+{
+  if (TYPEOF(offset) != INTSXP || XLENGTH(offset) < 1) {
+    error("offset must be a non-missing non-negative integer scalar");
+  }
+  int value = INTEGER(offset)[0];
+  if (value == NA_INTEGER || value < 0) {
+    error("offset must be a non-missing non-negative integer scalar");
+  }
+  return (ptrdiff_t) value;
+}
+
 SEXP C_isnullptr(SEXP x)
 {
   if (TYPEOF(x) != EXTPTRSXP) return ScalarLogical(FALSE);
@@ -30,6 +66,7 @@ SEXP C_isnullptr(SEXP x)
 SEXP C_asexternalptr(SEXP x)
 {
   if (isVector(x)) {
+    if (R_vector_data_size(x) == 0) error("x must have length greater zero");
     return R_MakeExternalPtr( R_vector_data_ptr(x), R_NilValue, x );
   }
   error("expected a vector type");
@@ -38,13 +75,16 @@ SEXP C_asexternalptr(SEXP x)
 
 SEXP C_offsetptr(SEXP x, SEXP offset)
 {
-  if ( LENGTH(offset) == 0 ) error("offset is missing");
-  ptrdiff_t offsetval = INTEGER(offset)[0];
+  ptrdiff_t offsetval = C_validate_offset(offset);
   unsigned char* ptr = 0;
   if (isVector(x)) {
+    ptrdiff_t size = R_vector_data_size(x);
+    if (size == 0) error("x must have length greater zero");
+    if (offsetval > size) error("offset %td is out-of-bounds of the R object (max size %td)", offsetval, size);
     ptr = (unsigned char*) R_vector_data_ptr(x);
   } else if (TYPEOF(x) == EXTPTRSXP ) {
     ptr = (unsigned char*) R_ExternalPtrAddr(x);
+    if (ptr == NULL) error("NULL address pointer");
   } else  {
     error("unsupported type");
   }


### PR DESCRIPTION
## Summary
Closes #9.

Harden low-level C argument handling so invalid typed pointer, packing, and offset inputs fail with R errors before unsafe pointer arithmetic or vector element reads.

## Changes
- Adds C-level validation helpers for low-level typed pointer signatures, struct metadata, `pack()`/`unpack()` signatures, bitfield ranges, and pointer offsets.
- Documents the refined typed pointer/vector compatibility rules and new offset/empty-vector requirements.
- Adds tinytest coverage with a small C fixture for typed pointer, null-pointer, type-mismatch, packing, and offset safeguards.