### PR TITLE
docs: run external examples in pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,7 +19,9 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      NOT_CRAN: "true"
       RDYNCALL_ARTICLE_EXTERNAL: "true"
+      RDYNCALL_EXAMPLES_EXTERNAL: "true"
       SDL3_VERSION: "3.4.10"
       SDL3_PREFIX: ${{ github.workspace }}/.cache/sdl3/3.4.10
     permissions:
@@ -83,7 +85,12 @@ jobs:
           needs: website
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: |
+          pkgdown::build_site_github_pages(
+            new_process = FALSE,
+            install = FALSE,
+            run_dont_run = identical(Sys.getenv("NOT_CRAN"), "true")
+          )
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/R/dynport.R
+++ b/R/dynport.R
@@ -106,9 +106,22 @@
 #'   \url{https://www.libsdl.org/}
 #'
 #' @examples
+#' \dontshow{run_external <- identical(Sys.getenv("RDYNCALL_EXAMPLES_EXTERNAL"), "true")}
 #' \dontrun{
-#' dynport(SDL3)
-#' dyn.SDL3::SDL_GetPlatform()
+#' if (run_external) {
+#'     portfile <- system.file("dynports", "SDL3.dynport",
+#'         package = "rdyncall", mustWork = TRUE
+#'     )
+#'     lib <- tempfile("rdyncall-dynport-lib")
+#'     generated <- dynport(
+#'         portfile = portfile,
+#'         package = "dyn.SDL3Example",
+#'         lib = lib,
+#'         rebuild = TRUE,
+#'         quiet = TRUE
+#'     )
+#'     getExportedValue(generated, "SDL_GetPlatform")()
+#' }
 #' }
 #' @aliases dynport_install_package dynport_load_into dynport_lib dynport_clear_lib
 #' @keywords programming interface

--- a/man/dynport.Rd
+++ b/man/dynport.Rd
@@ -132,9 +132,22 @@ other libraries, generate a DCF \code{.dynport} file externally and pass it with
 \code{portfile}.
 }
 \examples{
+\dontshow{run_external <- identical(Sys.getenv("RDYNCALL_EXAMPLES_EXTERNAL"), "true")}
 \dontrun{
-dynport(SDL3)
-dyn.SDL3::SDL_GetPlatform()
+if (run_external) {
+    portfile <- system.file("dynports", "SDL3.dynport",
+        package = "rdyncall", mustWork = TRUE
+    )
+    lib <- tempfile("rdyncall-dynport-lib")
+    generated <- dynport(
+        portfile = portfile,
+        package = "dyn.SDL3Example",
+        lib = lib,
+        rebuild = TRUE,
+        quiet = TRUE
+    )
+    getExportedValue(generated, "SDL_GetPlatform")()
+}
 }
 }
 \references{


### PR DESCRIPTION
## Summary

- Allow pkgdown to execute opted-in external DynPort examples while keeping CRAN default examples safe.
- Use the installed-package pkgdown path to exercise SDL3 DynPort generation without adding a public helper API.

## Changes

- Gate the `dynport()` SDL3 example behind a hidden `RDYNCALL_EXAMPLES_EXTERNAL` check inside the existing `\dontrun{}` example.
- Set pkgdown CI to run `\dontrun{}` examples with `NOT_CRAN=true` and `RDYNCALL_EXAMPLES_EXTERNAL=true`.
- Regenerate `man/dynport.Rd` from roxygen.
