### PR TITLE
Harden DynPort name validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
   rebuilding or rerunning a generated package in the same R session remains
   repeatable (#55).
 - Preserve original C symbol names in generated DynPort packages while
-  validating unsafe DynPort metadata and generated namespace/help output.
+  validating unsafe DynPort metadata and generated namespace/help output (#62).
 - Support `Constant` and `Variadic` fields in DCF DynPort files, including
   binding variadic entries through `dyncall_variadic()` (#53).
 - Add `dyncall_variadic()` for calling C variadic functions with explicit

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 - Keep DynPort parsing isolated from already attached generated packages so
   rebuilding or rerunning a generated package in the same R session remains
   repeatable (#55).
+- Preserve original C symbol names in generated DynPort packages while
+  validating unsafe DynPort metadata and generated namespace/help output.
 - Support `Constant` and `Variadic` fields in DCF DynPort files, including
   binding variadic entries through `dyncall_variadic()` (#53).
 - Add `dyncall_variadic()` for calling C variadic functions with explicit

--- a/R/dynport.R
+++ b/R/dynport.R
@@ -214,6 +214,39 @@ dynport_parse_env <- function() {
     new.env(parent = emptyenv())
 }
 
+dynport_is_object_name <- function(names) {
+    !is.na(names) & nzchar(names) & !grepl("[[:cntrl:]]|`", names)
+}
+
+dynport_check_names <- function(names, type, parent_name = NULL, lnums, values,
+                                what, allow_empty = FALSE, check_duplicates = FALSE) {
+    if (!length(names)) return(invisible(names))
+
+    invalid <- is.na(names) | grepl("[[:cntrl:]]|`", names)
+    if (!allow_empty) invalid <- invalid | !nzchar(names)
+    if (any(invalid)) {
+        dynport_issue_error(type, parent_name,
+            rep_len(lnums, length(names))[invalid],
+            rep_len(values, length(names))[invalid],
+            sprintf("Invalid %s name found", what)
+        )
+    }
+
+    if (check_duplicates) {
+        duplicates <- duplicated(names)
+        if (allow_empty) duplicates <- duplicates & nzchar(names)
+        if (any(duplicates)) {
+            dynport_issue_error(type, parent_name,
+                rep_len(lnums, length(names))[duplicates],
+                rep_len(values, length(names))[duplicates],
+                sprintf("Duplicate %s name found", what)
+            )
+        }
+    }
+
+    invisible(names)
+}
+
 dynport_parse_fields <- function(keys, values, lnums, envir = parent.frame()) {
     out <- mapply(dynport_parse_field,
         key = keys, value = values, lnum = lnums, MoreArgs = list(envir = envir),
@@ -226,7 +259,9 @@ dynport_parse_fields <- function(keys, values, lnums, envir = parent.frame()) {
         names(enums) <- vapply(out[is_enum], names, "", USE.NAMES = FALSE)
         out <- c(out[!is_enum], list(Enum = enums))
     }
-    dynport_apply_variadic_metadata(out)
+    out <- dynport_apply_variadic_metadata(out)
+    dynport_export_names(out)
+    out
 }
 
 dynport_parse_field <- function(key, value, lnum, envir = parent.frame()) {
@@ -244,7 +279,9 @@ dynport_parse_field <- function(key, value, lnum, envir = parent.frame()) {
             "Struct"   = dynport_parse_struct(value,   lnum, envir),
             "Union"    = dynport_parse_union(value,    lnum, envir),
             "Enum"     = dynport_parse_enum(value,     lnum, key = "Enum"),
-            NULL
+            dynport_issue_error("DynPort", NULL, lnum, paste0(key, ":"),
+                sprintf("Unknown DynPort field %s found", sQuote(key))
+            )
         )
     }
 }
@@ -258,7 +295,7 @@ dynport_parse_package <- function(value, lnum = 1L) {
 
     if (any(empty)) {
         val <- val[!empty]
-        lnum <- lnum[!lnum]
+        lnum <- lnum[!empty]
     }
 
     if (length(val) > 1L) {
@@ -273,7 +310,7 @@ dynport_parse_package <- function(value, lnum = 1L) {
         dynport_issue_error("Package", NULL, lnum, val, "At least two character long is required")
     }
 
-    if (!grepl("^[a-zA-z]", val)) {
+    if (!grepl("^[A-Za-z]", val)) {
         dynport_issue_error("Package", NULL, lnum, val, "First character should be a letter")
     }
 
@@ -293,7 +330,7 @@ dynport_parse_version <- function(value, lnum = 1L) {
 
     if (any(empty)) {
         val <- val[!empty]
-        lnum <- lnum[!lnum]
+        lnum <- lnum[!empty]
     }
 
     if (length(val) > 1L) {
@@ -351,11 +388,9 @@ dynport_parse_constant <- function(value, lnum = 1L) {
     }
 
     nms <- trimws(vapply(nms_vals, .subset2, "", 1L))
-    if (any(invld <- nms != make.names(nms))) {
-        dynport_issue_error("Constant", NULL, l[invld], s[invld],
-            "Invalid constant name found"
-        )
-    }
+    dynport_check_names(nms, "Constant", lnums = l, values = s,
+        what = "constant", check_duplicates = TRUE
+    )
 
     vals <- trimws(vapply(nms_vals, .subset2, "", 2L))
     parsed <- mapply(dynport_parse_constant_value, vals, l, s, SIMPLIFY = FALSE)
@@ -424,6 +459,9 @@ dynport_parse_function <- function(value, lnum = 1L, envir = parent.frame()) {
         if (!nchar(name)) {
             issue_error(NULL, "Missing name in specification")
         }
+        if (!dynport_is_object_name(name)) {
+            issue_error(NULL, "Invalid function name found")
+        }
 
         # split argument signature and return value
         if (!grepl(")", sig[[2L]], fixed = TRUE)) {
@@ -467,6 +505,15 @@ dynport_parse_function <- function(value, lnum = 1L, envir = parent.frame()) {
             nm <- nm[-length(nm)]
         }
         if (length(nm)) {
+            if (any(!dynport_is_object_name(nm))) {
+                issue_error(name, "Invalid argument name found")
+            }
+            if (any(nm == "...")) {
+                issue_error(name, "Fixed argument names must not be '...'")
+            }
+            if (variadic && any(nm == ".varargs")) {
+                issue_error(name, "Variadic argument names must not be '.varargs'")
+            }
             if (length(arg$type) != length(nm)) {
                 issue_error(name,
                     sprintf("Imbalance number of argument types (%s) and names (%s) found",
@@ -530,15 +577,9 @@ dynport_parse_variadic <- function(value, lnum = 1L, envir = parent.frame()) {
         )
     }
 
-    invld <- vals != make.names(vals)
-    if (any(invld)) {
-        dynport_issue_error("Variadic", NULL, lnum, vals[invld], "Invalid function name found")
-    }
-
-    dups <- unique(vals[duplicated(vals)])
-    if (length(dups)) {
-        dynport_issue_error("Variadic", NULL, lnum, dups, "Duplicate function name found")
-    }
+    dynport_check_names(vals, "Variadic", lnums = lnum, values = vals,
+        what = "function", check_duplicates = TRUE
+    )
 
     vals
 }
@@ -623,6 +664,9 @@ dynport_parse_struct_union <- function(value, lnum = 1L, envir = parent.frame(),
         if (!nchar(name)) {
             issue_error(NULL, "Missing name in specification")
         }
+        if (!dynport_is_object_name(name)) {
+            issue_error(NULL, sprintf("Invalid %s name found", kind))
+        }
 
         # split struct signature and field names
         if (!grepl("}", sig[[2L]], fixed = TRUE)) {
@@ -645,6 +689,17 @@ dynport_parse_struct_union <- function(value, lnum = 1L, envir = parent.frame(),
             # this is the case when there are extra '}'
             if (!nrow(field_layout$fields)) {
                 issue_error(name, "Extra '}' in specification")
+            }
+        }
+
+        field_names <- field_layout$fields$name
+        if (length(field_names)) {
+            named <- nzchar(field_names)
+            if (any(named & !dynport_is_object_name(field_names))) {
+                issue_error(name, "Invalid field name found")
+            }
+            if (any(duplicated(field_names[named]))) {
+                issue_error(name, "Duplicate field name found")
             }
         }
 
@@ -721,6 +776,7 @@ dynport_parse_enum <- function(value, lnum, key) {
 
     # get the enum name
     if (grepl("^Enum/", key)) key <- sub("^Enum/", "", key)
+    dynport_check_names(key, "Enum", lnums = lnum, values = key, what = "enum")
 
     # split member names and values by "="
     nms_vals <- strsplit(s, "=", fixed = TRUE)
@@ -734,12 +790,7 @@ dynport_parse_enum <- function(value, lnum, key) {
 
     # valid names
     nms <- trimws(vapply(nms_vals, .subset2, "", 1L))
-    # TODO: check if this is sufficient
-    if (any(invld <- nms != make.names(nms))) {
-        dynport_issue_error("Enum", key, l[invld], s[invld],
-            "Invalid member name found"
-        )
-    }
+    dynport_check_names(nms, "Enum", key, l, s, "member", check_duplicates = TRUE)
 
     # check values
     vals <- trimws(vapply(nms_vals, .subset2, "", 2L))
@@ -964,8 +1015,7 @@ dynport_export_names <- function(port) {
 }
 
 dynport_validate_export_names <- function(names) {
-    names <- names[nzchar(names)]
-    invalid <- names != make.names(names)
+    invalid <- !dynport_is_object_name(names)
     if (any(invalid)) {
         stop("Invalid export names found in 'dynport' file: ",
             paste(sQuote(names[invalid]), collapse = ", "),
@@ -1300,8 +1350,16 @@ dynport_write_description <- function(src, port, portname, package, dynport_file
 }
 
 dynport_write_namespace <- function(src, exports) {
-    lines <- if (length(exports)) paste0("export(", exports, ")") else character()
+    lines <- if (length(exports)) {
+        paste0("export(", vapply(exports, dynport_deparse_string, character(1L)), ")")
+    } else {
+        character()
+    }
     writeLines(lines, file.path(src, "NAMESPACE"), useBytes = TRUE)
+}
+
+dynport_deparse_string <- function(x) {
+    encodeString(as.character(x), quote = "\"")
 }
 
 dynport_write_loader <- function(src, dynport_file) {
@@ -1319,14 +1377,15 @@ dynport_write_man <- function(src, port) {
     if (!length(functions)) return(invisible())
 
     dir.create(file.path(src, "man"), recursive = TRUE, showWarnings = FALSE)
-    for (fun in functions) {
-        dynport_write_function_rd(src, fun)
+    for (i in seq_along(functions)) {
+        dynport_write_function_rd(src, functions[[i]], i)
     }
     invisible()
 }
 
-dynport_write_function_rd <- function(src, fun) {
+dynport_write_function_rd <- function(src, fun, index = 1L) {
     name <- fun$name
+    topic <- dynport_rd_topic(name, index)
     arg_names <- dynport_function_arg_names(fun)
     arg_types <- dynport_signature_types(fun$argument$sig)
     usage <- dynport_rd_usage(name, arg_names, isTRUE(fun$variadic))
@@ -1353,7 +1412,7 @@ dynport_write_function_rd <- function(src, fun) {
     }
 
     lines <- c(
-        paste0("\\name{", dynport_rd_escape(name), "}"),
+        paste0("\\name{", dynport_rd_escape(topic), "}"),
         paste0("\\alias{", dynport_rd_escape(name), "}"),
         paste0("\\title{", dynport_rd_escape(name), "}"),
         "\\usage{",
@@ -1369,7 +1428,12 @@ dynport_write_function_rd <- function(src, fun) {
         "\\keyword{programming}",
         "\\keyword{interface}"
     )
-    writeLines(lines, file.path(src, "man", paste0(name, ".Rd")), useBytes = TRUE)
+    writeLines(lines, file.path(src, "man", paste0(topic, ".Rd")), useBytes = TRUE)
+}
+
+dynport_rd_topic <- function(name, index) {
+    if (identical(dynport_formal_name(name), name)) return(name)
+    sprintf("dynport-function-%03d", index)
 }
 
 dynport_rd_usage <- function(name, arg_names, variadic = FALSE) {
@@ -1377,7 +1441,7 @@ dynport_rd_usage <- function(name, arg_names, variadic = FALSE) {
     if (variadic) {
         args <- c(args, "...", ".varargs = \"\"")
     }
-    paste0(name, "(", paste(args, collapse = ", "), ")")
+    paste0(dynport_formal_name(name), "(", paste(args, collapse = ", "), ")")
 }
 
 dynport_rd_type_description <- function(type) {

--- a/inst/tinytest/test_dynport.R
+++ b/inst/tinytest/test_dynport.R
@@ -49,15 +49,34 @@ expect_dynport_portfile_error(c("Version: 1", "  2"), "single string")
 # library
 expect_dynport_portfile_error(c("Library: com", " |.o"), "file name")
 
+# unknown fields
+expect_dynport_portfile_error("Functon: f()v;", "Unknown DynPort field")
+
 # constant
 expect_dynport_portfile_error("Constant: a", "constant specification")
-expect_dynport_portfile_error("Constant: a-b = 1", "constant name")
+expect_dynport_portfile_error("Constant: = 1", "constant name")
+expect_dynport_portfile_error("Constant: `bad` = 1", "constant name")
+expect_dynport_portfile_error(c("Constant:", "    DUP=1", "    DUP=2"), "Duplicate constant name")
 expect_dynport_portfile_error("Constant: a = b", "constant value")
+non_syntactic_constant <- rdyncall:::dynport_parse_constant("_CONST-VALUE = 1")
+expect_equal(non_syntactic_constant[["_CONST-VALUE"]], 1L)
 
 # enum
 expect_dynport_portfile_error("Enum: a = 1", "Invalid specification")
 expect_dynport_portfile_error("Enum/test: a = 1 b = 2", "member specification")
+expect_dynport_portfile_error("Enum/`bad`: a = 1", "enum name")
+expect_dynport_portfile_error("Enum/test: `bad` = 1", "member name")
+expect_dynport_portfile_error(c("Enum/test:", "    DUP=1", "    DUP=2"), "Duplicate member name")
 expect_dynport_portfile_error("Enum/test: a = 1.2", "member value")
+non_syntactic_enum <- rdyncall:::dynport_parse_enum("_ENUM-MEMBER = 1", 1L, "Enum/_Enum-Name")
+expect_equal(non_syntactic_enum[["_Enum-Name"]][["_ENUM-MEMBER"]], 1L)
+
+expect_dynport_portfile_error(c(
+    "Constant:",
+    "    SAME=1",
+    "Enum/SAME:",
+    "    SAME_MEMBER=1"
+), "Duplicate export names")
 
 local({
     search_name <- "package:rdyncallDynportCollision"
@@ -82,9 +101,12 @@ expect_dynport_portfile_error(c("Struct: test{", " }}"), "\\}")
 expect_dynport_portfile_error("Struct: a = 1", "\\{")
 expect_dynport_portfile_error(c("Struct: s", " {1"), "\\}")
 expect_dynport_portfile_error("Struct: {}", "name")
+expect_dynport_portfile_error("Struct: `bad`{i} a", "struct name")
 expect_dynport_portfile_error("Struct: test{ab}", "type name")
 expect_dynport_portfile_error("Struct: test{ii}a", "number")
 expect_dynport_portfile_error("Struct: test{i} a b", "number")
+expect_dynport_portfile_error("Struct: test{ii} a a", "field name")
+expect_dynport_portfile_error("Struct: test{i} `bad`", "field name")
 expect_dynport_portfile_error("Struct: test{d} a:1", "integer")
 expect_dynport_portfile_error("Struct: test{I} a:33", "exceeds")
 expect_dynport_portfile_error("Struct: test{I} a:0", "zero-width")
@@ -97,6 +119,8 @@ packed_struct <- rdyncall:::dynport_parse_struct("PackedDyn{Cd} c d @packed;")
 expect_equal(packed_struct$PackedDyn$size, 9L)
 expect_equal(packed_struct$PackedDyn$align, 1L)
 expect_equal(packed_struct$PackedDyn$fields$offset, c(0L, 1L))
+non_syntactic_struct <- rdyncall:::dynport_parse_struct("_Struct-Name{i} _field-name;")
+expect_equal(non_syntactic_struct[["_Struct-Name"]]$fields$name, "_field-name")
 
 # union
 expect_dynport_portfile_error(c("Union: test", " }"), "\\{")
@@ -104,9 +128,11 @@ expect_dynport_portfile_error(c("Union: test{", " }}"), "\\}")
 expect_dynport_portfile_error("Union: a = 1", "\\{")
 expect_dynport_portfile_error(c("Union: s", " {1"), "\\}")
 expect_dynport_portfile_error("Union: {}", "name")
+expect_dynport_portfile_error("Union: `bad`{i} a", "union name")
 expect_dynport_portfile_error("Union: test{ab}", "type name")
 expect_dynport_portfile_error("Union: test{ii}a", "number")
 expect_dynport_portfile_error("Union: test{i} a b", "number")
+expect_dynport_portfile_error("Union: test{ii} a a", "field name")
 expect_dynport_portfile_error("Union: test{d} a:1", "integer")
 expect_dynport_portfile_error("Union: test{C} c @align(3)", "power-of-two")
 
@@ -125,12 +151,20 @@ expect_dynport_portfile_error(c("Function: test(", " ))"), "Extra")
 expect_dynport_portfile_error("Function: a = 1", "spec")
 expect_dynport_portfile_error(c("Function: s", " (1"), "\\)")
 expect_dynport_portfile_error("Function: ()", "name")
+expect_dynport_portfile_error("Function: `bad`()v;", "function name")
 expect_dynport_portfile_error("Function: test(ab)", "return")
 expect_dynport_portfile_error("Function: test(ii)a", "type name")
 expect_dynport_portfile_error("Function: test(C[2])v arg", "C\\[2\\].*argument")
 expect_dynport_portfile_error("Function: test(i) i a b", "number")
 expect_dynport_portfile_error("Function: test(ii)i a a", "name")
+expect_dynport_portfile_error("Function: test(i)i `bad`", "argument name")
+expect_dynport_portfile_error("Function: test(i)i ...", "Fixed argument names")
+expect_dynport_portfile_error("Function: test(i.)i .varargs ...", "Variadic argument names")
 expect_dynport_portfile_error("Function: test(i.i)v x y", "Variadic marker")
+
+non_syntactic_function <- rdyncall:::dynport_parse_function("_weird-function(i)v _arg-name;")
+expect_equal(names(non_syntactic_function), "_weird-function")
+expect_equal(non_syntactic_function[["_weird-function"]]$argument$name, "_arg-name")
 
 inline_variadic <- rdyncall:::dynport_parse_function("printf(Z.)i fmt ...;")
 expect_true(inline_variadic$printf$variadic)
@@ -159,6 +193,14 @@ expect_dynport_portfile_error(c(
     "Variadic:",
     "    printf"
 ), "not defined")
+expect_dynport_portfile_error(c(
+    "Package: VarDuplicate",
+    "Function:",
+    "    printf()v;",
+    "Variadic:",
+    "    printf",
+    "    printf"
+), "Duplicate function name")
 
 parsed_port <- rdyncall:::dynport_read(write_dynport(c(
     "Package: ParsePort",
@@ -174,6 +216,29 @@ expect_equal(parsed_port$Constant$PARSE_INT, 32L)
 expect_equal(parsed_port$Constant$PARSE_WIDE, 2147483648)
 expect_equal(parsed_port$Constant$PARSE_STR, "hello")
 expect_true(parsed_port$Function$parse_printf$variadic)
+
+local({
+    portfile <- write_dynport(c(
+        "Package: WeirdFunction",
+        "Version: 1.0.0",
+        "Function:",
+        "    _weird-function(i)v _arg-name;"
+    ))
+    port <- rdyncall:::dynport_read(portfile)
+    src <- rdyncall:::dynport_create_package_source(
+        port, portfile, "weird_function", "dyn.WeirdFunction", "md5"
+    )
+    on.exit(unlink(src, recursive = TRUE, force = TRUE), add = TRUE)
+
+    ns <- readLines(file.path(src, "NAMESPACE"))
+    expect_true('export("_weird-function")' %in% ns)
+
+    rd <- file.path(src, "man", "dynport-function-001.Rd")
+    expect_true(file.exists(rd))
+    rd_text <- readLines(rd)
+    expect_true(any(grepl("`_weird-function`(`_arg-name`)", rd_text, fixed = TRUE)))
+    expect_silent(tools::parse_Rd(rd))
+})
 
 empty_port <- tempfile(fileext = ".dynport")
 expect_true(file.create(empty_port))
@@ -233,6 +298,28 @@ local({
     expect_equal(getExportedValue(package, "TINY_STR"), "tiny")
     expect_equal(getExportedValue(package, "TINY_ONE"), 1L)
     expect_true("package:dyn.TinyPort" %in% search())
+})
+
+local({
+    portfile <- write_dynport(c(
+        "Package: WeirdNames",
+        "Version: 1.0.0",
+        "Constant:",
+        "    _CONST-VALUE=42",
+        "Enum/_Enum-Name:",
+        "    _ENUM-MEMBER=1",
+        "Struct:",
+        "    _Struct-Name{i} _field-name;"
+    ))
+    lib <- tempfile("rdyncall-dynport-lib")
+    package <- "dyn.WeirdNames"
+    unload_test_package(package)
+    on.exit(unload_test_package(package), add = TRUE)
+
+    expect_silent(dynport(weird_names, portfile = portfile, lib = lib, quiet = TRUE))
+    expect_equal(getExportedValue(package, "_CONST-VALUE"), 42L)
+    expect_equal(getExportedValue(package, "_ENUM-MEMBER"), 1L)
+    expect_true(inherits(getExportedValue(package, "_Struct-Name"), "typeinfo"))
 })
 
 local({


### PR DESCRIPTION
## Summary
Harden DynPort metadata validation while preserving original C symbol names in generated R packages.

## Changes
- Quote generated NAMESPACE exports and Rd usage so non-syntactic C names can remain intact.
- Reject unsafe DynPort names, unknown fields, duplicate exports, and duplicate arguments, members, or fields during parsing.
- Add DynPort tests for preserved non-syntactic names and update NEWS.