### PR TITLE
fix: avoid writing fixture objects into package library

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,4 @@
 ^src/dyncall/dyncall/libdyncall_s\.a$
 ^src/dyncall/dyncallback/libdyncallback_s\.a$
 ^src/dyncall/dynload/libdynload_s\.a$
+^CRAN-SUBMISSION$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,14 +32,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,    r: 'release', id: 'macos-arm64'}
-          - {os: macos-15-intel,  r: 'release', id: 'macos-intel'}
-          - {os: windows-latest,  r: 'release', id: 'windows-release'}
-          - {os: windows-latest,  r: 'oldrel-4', id: 'windows-oldrel-4'}
-          - {os: ubuntu-latest,   r: 'devel', id: 'ubuntu-devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release', id: 'ubuntu-release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1', id: 'ubuntu-oldrel-1'}
-          - {os: ubuntu-latest,   r: 'oldrel-4', id: 'ubuntu-oldrel-4'}
+          - {os: macos-latest,    r: 'release', id: 'macos-arm64', dependencies: 'all'}
+          - {os: macos-15-intel,  r: 'release', id: 'macos-intel', dependencies: 'all'}
+          - {os: windows-latest,  r: 'release', id: 'windows-release', dependencies: 'all'}
+          - {os: windows-latest,  r: 'oldrel-4', id: 'windows-oldrel-4', dependencies: 'hard'}
+          - {os: ubuntu-latest,   r: 'devel', id: 'ubuntu-devel', http-user-agent: 'release', dependencies: 'all'}
+          - {os: ubuntu-latest,   r: 'release', id: 'ubuntu-release', dependencies: 'all'}
+          - {os: ubuntu-latest,   r: 'oldrel-1', id: 'ubuntu-oldrel-1', dependencies: 'all'}
+          - {os: ubuntu-latest,   r: 'oldrel-4', id: 'ubuntu-oldrel-4', dependencies: 'hard'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -58,8 +58,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            any::tinytest
           needs: check
+          dependencies: ${{ matrix.config.dependencies }}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,14 +32,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,    r: 'release', id: 'macos-arm64', dependencies: 'all'}
-          - {os: macos-15-intel,  r: 'release', id: 'macos-intel', dependencies: 'all'}
-          - {os: windows-latest,  r: 'release', id: 'windows-release', dependencies: 'all'}
-          - {os: windows-latest,  r: 'oldrel-4', id: 'windows-oldrel-4', dependencies: 'hard'}
-          - {os: ubuntu-latest,   r: 'devel', id: 'ubuntu-devel', http-user-agent: 'release', dependencies: 'all'}
-          - {os: ubuntu-latest,   r: 'release', id: 'ubuntu-release', dependencies: 'all'}
-          - {os: ubuntu-latest,   r: 'oldrel-1', id: 'ubuntu-oldrel-1', dependencies: 'all'}
-          - {os: ubuntu-latest,   r: 'oldrel-4', id: 'ubuntu-oldrel-4', dependencies: 'hard'}
+          - {os: macos-latest,    r: 'release', id: 'macos-arm64', dependencies: '"all"'}
+          - {os: macos-15-intel,  r: 'release', id: 'macos-intel', dependencies: '"all"'}
+          - {os: windows-latest,  r: 'release', id: 'windows-release', dependencies: '"all"'}
+          - {os: windows-latest,  r: 'oldrel-4', id: 'windows-oldrel-4', dependencies: '"hard"'}
+          - {os: ubuntu-latest,   r: 'devel', id: 'ubuntu-devel', http-user-agent: 'release', dependencies: '"all"'}
+          - {os: ubuntu-latest,   r: 'release', id: 'ubuntu-release', dependencies: '"all"'}
+          - {os: ubuntu-latest,   r: 'oldrel-1', id: 'ubuntu-oldrel-1', dependencies: '"all"'}
+          - {os: ubuntu-latest,   r: 'oldrel-4', id: 'ubuntu-oldrel-4', dependencies: '"hard"'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,21 +1,27 @@
 Package: rdyncall
-Version: 0.10.0
+Version: 0.10.1
 Title: Improved Foreign Function Interface and Dynamic Bindings to C Libraries
 Authors@R: c(
     person("Daniel", "Adler", role = c("aut", "cph"),
            email = "dadler@uni-goettingen.de"),
     person("Hongyuan", "Jia", role = c("aut", "cre", "cph"),
-           email = "hongyuanjia@cqust.edu.cn")
+           email = "hongyuanjia@cqust.edu.cn"),
+    person("Tassilo", "Philipp", role = c("ctb", "cph"),
+           email = "tphilipp@potion-studios.com"),
+    person("Olivier", "Chafik", role = c("ctb", "cph"),
+           email = "olivier.chafik@gmail.com")
     )
 Depends: R (>= 3.0.0)
-Description: Provides a cross-platform framework for dynamic binding of C libraries using a flexible Foreign Function Interface ('FFI').
-  The FFI supports almost all fundamental C types, multiple calling conventions, symbolic access to foreign C 'struct'/'union' data types and wrapping of R functions as C callback function pointers.
-  Dynamic bindings to shared C libraries are data-driven by cross-platform binding specifications using a compact plain text format; the package includes an 'SDL3' DynPort generated from current headers with 'porter'.
-  The package includes a variety of technology demos and OS-specific notes for installation of shared libraries.
+Description: Provides a cross-platform framework for dynamic binding of C libraries using a flexible Foreign Function Interface (FFI).
+  The FFI supports almost all fundamental C types, multiple calling conventions, symbolic access to foreign C struct/union data types and wrapping of R functions as C callback function pointers.
+  Dynamic bindings to shared C libraries are data-driven by cross-platform binding specifications using a compact plain text format; the package includes a 'DynPort' binding specification for 'SDL3' generated from current headers with 'porter'.
+  The package includes a variety of technology demos and OS-specific notes for installation of shared libraries. For the underlying methods and bundled 'DynCall' libraries, see Adler (2012) <doi:10.32614/RJ-2012-004> and Adler and Philipp (2008) <https://dyncall.org>.
 License: MIT + file LICENSE
 URL: https://github.com/hongyuanjia/rdyncall, https://dyncall.org
 BugReports: https://github.com/hongyuanjia/rdyncall/issues
-Suggests: tinytest
+Suggests:
+    Rtinycc,
+    tinytest
 Config/Needs/website: r-lib/asciicast
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# rdyncall 0.10.1
+
+- Build compiled tinytest fixtures from temporary source copies so CRAN checks
+  do not try to write object files into the read-only installed package library.
+
 # rdyncall 0.10.0
 
 - Restore package compilation on current R toolchains (#19).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # rdyncall 0.10.1
 
 - Build compiled tinytest fixtures from temporary source copies so CRAN checks
-  do not try to write object files into the read-only installed package library.
+  do not try to write object files into the read-only installed package library
+  (#68).
 
 # rdyncall 0.10.0
 

--- a/R/dynport.R
+++ b/R/dynport.R
@@ -107,7 +107,7 @@
 #'
 #' @examples
 #' \dontshow{run_external <- identical(Sys.getenv("RDYNCALL_EXAMPLES_EXTERNAL"), "true")}
-#' \dontrun{
+#' \donttest{
 #' if (run_external) {
 #'     portfile <- system.file("dynports", "SDL3.dynport",
 #'         package = "rdyncall", mustWork = TRUE

--- a/R/struct.R
+++ b/R/struct.R
@@ -756,6 +756,24 @@ make_struct_info <- function(name, signature, field_names, envir = parent.frame(
 #'        by field index.
 #' @param ... additional arguments to be passed to [base::print()] method.
 #'
+#' @return
+#' The functions in this help topic have the following return values:
+#'
+#' - `cstruct()` and `cunion()` return `NULL`; they are called for the side
+#'   effect of registering `typeinfo` objects in `envir`.
+#' - `cdata()` returns an atomic raw vector of S3 class `struct`. The raw bytes
+#'   store an R-managed C aggregate object, and attributes record its
+#'   run-time type information.
+#' - `as.ctype()` returns `x` tagged with S3 classes `ctype` and `struct`,
+#'   together with the associated type-information attributes.
+#' - The `$.struct` method returns the named field converted from its
+#'   underlying C representation. Fixed-size arrays return a vector or list, and
+#'   nested aggregate fields return `struct` object(s).
+#' - The `$<-.struct` method returns the modified `struct` object after packing
+#'   the replacement value into the selected field.
+#' - `print.struct()` and `print.ctype()` return `x` invisibly after printing a
+#'   field summary.
+#'
 #' @seealso
 #' [dyncall()] for type signatures and [typeinfo()] for details on run-time type
 #' information S3 objects.

--- a/README.Rmd
+++ b/README.Rmd
@@ -9,6 +9,7 @@ library(rdyncall)
 # rdyncall <img src="man/figures/logo.svg" alt="rdyncall logo" align="right" height="138" />
 
 <!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version/rdyncall)](https://CRAN.R-project.org/package=rdyncall)
 [![R-CMD-check](https://github.com/hongyuanjia/rdyncall/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/hongyuanjia/rdyncall/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
@@ -54,11 +55,14 @@ drawing calls and drive a rotating 3D scene.
 ## Installation
 
 ```r
-remotes::install_github("hongyuanjia/rdyncall")
+install.packages("rdyncall")
 ```
 
-`rdyncall` was previously archived on CRAN. This repository contains the active
-modernization work toward a maintainable package and current R toolchains.
+You can install the development version from GitHub:
+
+```r
+remotes::install_github("hongyuanjia/rdyncall")
+```
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 <!-- badges: start -->
 
+[![CRAN status](https://www.r-pkg.org/badges/version/rdyncall)](https://CRAN.R-project.org/package=rdyncall)
 [![R-CMD-check](https://github.com/hongyuanjia/rdyncall/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/hongyuanjia/rdyncall/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
@@ -71,12 +72,14 @@ raylib 3D rendering from R
 ## Installation
 
 ``` r
-remotes::install_github("hongyuanjia/rdyncall")
+install.packages("rdyncall")
 ```
 
-`rdyncall` was previously archived on CRAN. This repository contains the
-active modernization work toward a maintainable package and current R
-toolchains.
+You can install the development version from GitHub:
+
+``` r
+remotes::install_github("hongyuanjia/rdyncall")
+```
 
 ## Quick Start
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,29 @@
+## Resubmission
+
+This maintenance release fixes the CRAN r-devel Debian check error reported for
+`rdyncall` 0.10.0. The tinytest helpers that compile C fixtures now copy those
+fixture sources to the R session temporary directory before invoking
+`R CMD SHLIB`, so object files are no longer written beside C files in the
+read-only installed package library.
+
+The previous resubmission addressed CRAN review feedback:
+
+* Removed single quotes around the FFI acronym and C `struct`/`union` keywords
+  in `DESCRIPTION` while keeping single quotes only for software, package and
+  API names.
+* Added method references to `DESCRIPTION` in CRAN's requested auto-linking
+  form.
+* Added a roxygen `@return` description for the exported aggregate helpers
+  documented in `struct.Rd`, then regenerated the Rd files.
+* Replaced the remaining `\dontrun{}` example wrapper with `\donttest{}` while
+  keeping the existing external-library guard for the SDL3 DynPort example.
+* Added `Rtinycc` to `Suggests` for optional demos that use it, and adjusted the
+  SDL3 demo to avoid static references to the runtime-generated `dyn.SDL3`
+  package.
+* Added Tassilo Philipp and Olivier Chafik to `Authors@R` with contributor and
+  copyright-holder roles for the bundled DynCall and dynload source notices
+  already preserved in `inst/COPYRIGHTS`.
+
 ## CRAN archive status
 
 This is a restored submission of `rdyncall`, which was orphaned and archived

--- a/demo/SDL.R
+++ b/demo/SDL.R
@@ -8,14 +8,11 @@ source(system.file("demo-support", "sdl3.R", package = "rdyncall", mustWork = TR
 
 # Run an SDL3 snake game through wrappers generated from SDL3.dynport.
 run_sdl_demo <- function() {
-    # Generate dyn.SDL3 in a temporary library so this demo leaves no generated
-    # package behind after it exits.
-    dynport_lib <- tempfile("rdyncall-sdl3-demo-lib-")
-    dir.create(dynport_lib, recursive = TRUE)
+    # Load the generated SDL3 bindings into a local environment. Keeping the
+    # demo package-free avoids declaring a runtime-generated package in CRAN
+    # demo dependency checks.
+    sdl <- new.env(parent = globalenv())
     dynport_file <- NULL
-    old_libpaths <- .libPaths()
-    dyn_sdl3_was_attached <- "package:dyn.SDL3" %in% search()
-    dyn_sdl3_was_loaded <- "dyn.SDL3" %in% loadedNamespaces()
 
     sdl_initialized <- FALSE
     window <- NULL
@@ -23,35 +20,22 @@ run_sdl_demo <- function() {
     on.exit(
         {
             if (!is.null(renderer) && !is.nullptr(renderer)) {
-                try(dyn.SDL3::SDL_DestroyRenderer(renderer), silent = TRUE)
+                try(sdl$SDL_DestroyRenderer(renderer), silent = TRUE)
             }
             if (!is.null(window) && !is.nullptr(window)) {
-                try(dyn.SDL3::SDL_DestroyWindow(window), silent = TRUE)
+                try(sdl$SDL_DestroyWindow(window), silent = TRUE)
             }
             if (sdl_initialized) {
-                try(dyn.SDL3::SDL_Quit(), silent = TRUE)
+                try(sdl$SDL_Quit(), silent = TRUE)
             }
-            if (!dyn_sdl3_was_attached && "package:dyn.SDL3" %in% search()) {
-                try(
-                    detach("package:dyn.SDL3", character.only = TRUE),
-                    silent = TRUE
-                )
-            }
-            if (!dyn_sdl3_was_loaded && "dyn.SDL3" %in% loadedNamespaces()) {
-                try(unloadNamespace("dyn.SDL3"), silent = TRUE)
-            }
-            .libPaths(old_libpaths)
-            if (!is.null(dynport_file)) {
-                unlink(dynport_file, force = TRUE)
-            }
-            unlink(dynport_lib, recursive = TRUE, force = TRUE)
+            if (!is.null(dynport_file)) unlink(dynport_file, force = TRUE)
         },
         add = TRUE
     )
 
     dynport_file <- sdl3_demo_dynport()
     tryCatch(
-        dynport(SDL3, portfile = dynport_file, lib = dynport_lib, rebuild = TRUE, quiet = FALSE),
+        dynport_load_into(dynport_file, envir = sdl),
         error = function(e) {
             stop(
                 conditionMessage(e),
@@ -71,12 +55,12 @@ run_sdl_demo <- function() {
     SDL_INIT_VIDEO <- 0x00000020L
 
     # Initialize SDL and use on.exit() to keep native resources paired.
-    if (!isTRUE(dyn.SDL3::SDL_Init(SDL_INIT_VIDEO))) {
-        stop("SDL_Init failed: ", dyn.SDL3::SDL_GetError(), call. = FALSE)
+    if (!isTRUE(sdl$SDL_Init(SDL_INIT_VIDEO))) {
+        stop("SDL_Init failed: ", sdl$SDL_GetError(), call. = FALSE)
     }
     sdl_initialized <- TRUE
 
-    window <- dyn.SDL3::SDL_CreateWindow(
+    window <- sdl$SDL_CreateWindow(
         "rdyncall SDL3 Snake",
         width,
         height,
@@ -85,23 +69,23 @@ run_sdl_demo <- function() {
     if (is.null(window) || is.nullptr(window)) {
         stop(
             "SDL_CreateWindow failed: ",
-            dyn.SDL3::SDL_GetError(),
+            sdl$SDL_GetError(),
             call. = FALSE
         )
     }
 
-    renderer <- dyn.SDL3::SDL_CreateRenderer(window, NULL)
+    renderer <- sdl$SDL_CreateRenderer(window, NULL)
     if (is.null(renderer) || is.nullptr(renderer)) {
         stop(
             "SDL_CreateRenderer failed: ",
-            dyn.SDL3::SDL_GetError(),
+            sdl$SDL_GetError(),
             call. = FALSE
         )
     }
 
     # Construct an SDL_FRect value for one grid cell.
     make_rect <- function(x, y, w = block - 2L, h = block - 2L) {
-        rect <- cdata(dyn.SDL3::SDL_FRect)
+        rect <- cdata(sdl$SDL_FRect)
         rect$x <- as.numeric(x)
         rect$y <- as.numeric(y)
         rect$w <- as.numeric(w)
@@ -111,7 +95,7 @@ run_sdl_demo <- function() {
 
     # Set the current renderer color. SDL expects unsigned byte RGBA channels.
     set_color <- function(r, g, b, a = 255L) {
-        dyn.SDL3::SDL_SetRenderDrawColor(
+        sdl$SDL_SetRenderDrawColor(
             renderer,
             as.integer(r),
             as.integer(g),
@@ -124,7 +108,7 @@ run_sdl_demo <- function() {
     draw_cell <- function(x, y, color) {
         do.call(set_color, as.list(color))
         rect <- make_rect((x - 1L) * block + 1L, (y - 1L) * block + 1L)
-        dyn.SDL3::SDL_RenderFillRect(renderer, rect)
+        sdl$SDL_RenderFillRect(renderer, rect)
     }
 
     # Pick a random empty grid cell for food.
@@ -196,7 +180,7 @@ run_sdl_demo <- function() {
     # Render one frame and show FPS/score text through SDL_RenderDebugText.
     render_game <- function(game, fps) {
         set_color(10L, 12L, 16L)
-        dyn.SDL3::SDL_RenderClear(renderer)
+        sdl$SDL_RenderClear(renderer)
 
         draw_cell(game$food$x, game$food$y, c(230L, 57L, 70L, 255L))
         for (i in seq_len(nrow(game$snake))) {
@@ -209,19 +193,19 @@ run_sdl_demo <- function() {
         }
 
         set_color(255L, 255L, 255L)
-        dyn.SDL3::SDL_RenderDebugText(
+        sdl$SDL_RenderDebugText(
             renderer,
             8,
             8,
             sprintf("FPS %.0f  Score %d", fps, game$score)
         )
-        dyn.SDL3::SDL_RenderPresent(renderer)
+        sdl$SDL_RenderPresent(renderer)
     }
 
     # Main loop: poll events, read keyboard state, update game logic at a fixed
     # cadence, and render as often as the loop allows.
     game <- reset_game()
-    event <- cdata(dyn.SDL3::SDL_Event)
+    event <- cdata(sdl$SDL_Event)
     last_step <- proc.time()[["elapsed"]]
     started <- last_step
     last_fps <- last_step
@@ -234,26 +218,26 @@ run_sdl_demo <- function() {
 
     cat("Use arrow keys to steer; press R to restart or Esc to exit.\n")
     repeat {
-        while (isTRUE(dyn.SDL3::SDL_PollEvent(event))) {
-            if (unpack(event, 0L, "I") == dyn.SDL3::SDL_EVENT_QUIT) {
+        while (isTRUE(sdl$SDL_PollEvent(event))) {
+            if (unpack(event, 0L, "I") == sdl$SDL_EVENT_QUIT) {
                 return(invisible(TRUE))
             }
         }
 
-        keys <- dyn.SDL3::SDL_GetKeyboardState(NULL)
-        if (pressed(keys, dyn.SDL3::SDL_SCANCODE_ESCAPE)) {
+        keys <- sdl$SDL_GetKeyboardState(NULL)
+        if (pressed(keys, sdl$SDL_SCANCODE_ESCAPE)) {
             return(invisible(TRUE))
         }
-        if (pressed(keys, dyn.SDL3::SDL_SCANCODE_R)) {
+        if (pressed(keys, sdl$SDL_SCANCODE_R)) {
             game <- reset_game()
         }
-        if (pressed(keys, dyn.SDL3::SDL_SCANCODE_RIGHT)) {
+        if (pressed(keys, sdl$SDL_SCANCODE_RIGHT)) {
             game <- change_direction(game, c(1L, 0L))
-        } else if (pressed(keys, dyn.SDL3::SDL_SCANCODE_LEFT)) {
+        } else if (pressed(keys, sdl$SDL_SCANCODE_LEFT)) {
             game <- change_direction(game, c(-1L, 0L))
-        } else if (pressed(keys, dyn.SDL3::SDL_SCANCODE_UP)) {
+        } else if (pressed(keys, sdl$SDL_SCANCODE_UP)) {
             game <- change_direction(game, c(0L, -1L))
-        } else if (pressed(keys, dyn.SDL3::SDL_SCANCODE_DOWN)) {
+        } else if (pressed(keys, sdl$SDL_SCANCODE_DOWN)) {
             game <- change_direction(game, c(0L, 1L))
         }
 
@@ -267,7 +251,7 @@ run_sdl_demo <- function() {
             fps <- frames / (now - last_fps)
             frames <- 0L
             last_fps <- now
-            dyn.SDL3::SDL_SetWindowTitle(
+            sdl$SDL_SetWindowTitle(
                 window,
                 sprintf("rdyncall SDL3 Snake - %.0f FPS", fps)
             )
@@ -277,7 +261,7 @@ run_sdl_demo <- function() {
         if (now - started >= duration) {
             return(invisible(TRUE))
         }
-        dyn.SDL3::SDL_Delay(16L)
+        sdl$SDL_Delay(16L)
     }
 }
 

--- a/inst/tinytest/test_arg_safeguards.R
+++ b/inst/tinytest/test_arg_safeguards.R
@@ -4,9 +4,15 @@ build_argument_safeguards_fixture <- function() {
     outdir <- tempfile("rdyncall-argument-safeguards-")
     dir.create(outdir)
     outdir <- normalizePath(outdir, winslash = "/", mustWork = TRUE)
+    src_copy <- file.path(outdir, basename(src))
+    # CRAN check libraries are read-only, so compile a temporary source copy
+    # instead of letting R CMD SHLIB create object files beside the installed C file.
+    if (!file.copy(src, src_copy, overwrite = TRUE)) {
+        stop("failed to copy argument safeguard test fixture source", call. = FALSE)
+    }
     lib <- file.path(outdir, paste0("argument_safeguards", .Platform$dynlib.ext))
     out <- system2(file.path(R.home("bin"), "R"),
-        c("CMD", "SHLIB", "-o", lib, src),
+        c("CMD", "SHLIB", "-o", lib, src_copy),
         stdout = TRUE, stderr = TRUE
     )
     if (!is.null(attr(out, "status"))) {

--- a/inst/tinytest/test_dynbind.R
+++ b/inst/tinytest/test_dynbind.R
@@ -26,9 +26,15 @@ build_dynbind_fixture <- function() {
     outdir <- tempfile("rdyncall-dynbind-fixture-")
     dir.create(outdir)
     outdir <- normalizePath(outdir, winslash = "/", mustWork = TRUE)
+    src_copy <- file.path(outdir, basename(src))
+    # CRAN check libraries are read-only, so compile a temporary source copy
+    # instead of letting R CMD SHLIB create object files beside the installed C file.
+    if (!file.copy(src, src_copy, overwrite = TRUE)) {
+        stop("failed to copy dynbind test fixture source", call. = FALSE)
+    }
     lib <- file.path(outdir, paste0("dynbind", .Platform$dynlib.ext))
     out <- system2(file.path(R.home("bin"), "R"),
-        c("CMD", "SHLIB", "-o", lib, src),
+        c("CMD", "SHLIB", "-o", lib, src_copy),
         stdout = TRUE, stderr = TRUE
     )
     if (!is.null(attr(out, "status"))) {

--- a/man/dynport.Rd
+++ b/man/dynport.Rd
@@ -133,7 +133,7 @@ other libraries, generate a DCF \code{.dynport} file externally and pass it with
 }
 \examples{
 \dontshow{run_external <- identical(Sys.getenv("RDYNCALL_EXAMPLES_EXTERNAL"), "true")}
-\dontrun{
+\donttest{
 if (run_external) {
     portfile <- system.file("dynports", "SDL3.dynport",
         package = "rdyncall", mustWork = TRUE

--- a/man/rdyncall-package.Rd
+++ b/man/rdyncall-package.Rd
@@ -98,5 +98,11 @@ Authors:
   \item Daniel Adler \email{dadler@uni-goettingen.de} [copyright holder]
 }
 
+Other contributors:
+\itemize{
+  \item Tassilo Philipp \email{tphilipp@potion-studios.com} [contributor, copyright holder]
+  \item Olivier Chafik \email{olivier.chafik@gmail.com} [contributor, copyright holder]
+}
+
 }
 \keyword{internal}

--- a/man/struct.Rd
+++ b/man/struct.Rd
@@ -47,6 +47,25 @@ by field index.}
 
 \item{...}{additional arguments to be passed to \code{\link[base:print]{base::print()}} method.}
 }
+\value{
+The functions in this help topic have the following return values:
+\itemize{
+\item \code{cstruct()} and \code{cunion()} return \code{NULL}; they are called for the side
+effect of registering \code{typeinfo} objects in \code{envir}.
+\item \code{cdata()} returns an atomic raw vector of S3 class \code{struct}. The raw bytes
+store an R-managed C aggregate object, and attributes record its
+run-time type information.
+\item \code{as.ctype()} returns \code{x} tagged with S3 classes \code{ctype} and \code{struct},
+together with the associated type-information attributes.
+\item The \verb{$.struct} method returns the named field converted from its
+underlying C representation. Fixed-size arrays return a vector or list, and
+nested aggregate fields return \code{struct} object(s).
+\item The \verb{$<-.struct} method returns the modified \code{struct} object after packing
+the replacement value into the selected field.
+\item \code{print.struct()} and \code{print.ctype()} return \code{x} invisibly after printing a
+field summary.
+}
+}
 \description{
 Functions for allocation, access and registration of foreign C \code{struct} and
 \code{union} data type.


### PR DESCRIPTION
## Summary

Closes #67.

Synchronizes the repository with the accepted `rdyncall` `0.10.0` CRAN resubmission changes and prepares `rdyncall` `0.10.1` for the CRAN Debian check failure where `R CMD SHLIB` attempted to write `*.o` files into the read-only installed package library.

## Changes

- Copies `argument_safeguards.c` and `dynbind.c` into the R session temporary directory before compiling the `tinytest` fixtures.
- Updates `DESCRIPTION`, `cran-comments.md`, and `NEWS.md` for the `0.10.1` maintenance release.
- Carries forward the accepted CRAN resubmission metadata, `Authors@R`, `Rtinycc` `Suggests`, regenerated `Rd` documentation, `README` CRAN install instructions, and `demo/SDL.R` dependency-scan cleanup.
- Keeps `CRAN-SUBMISSION` out of source builds via `.Rbuildignore`.
