### PR TITLE
fix: make `dynunload()` idempotent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rdyncall
-Version: 0.10.1
+Version: 0.10.2
 Title: Improved Foreign Function Interface and Dynamic Bindings to C Libraries
 Authors@R: c(
     person("Daniel", "Adler", role = c("aut", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # rdyncall 0.10.2
 
 - Make `dynunload()` idempotent after explicit unloads so finalizers do not
-  attempt to unload the same dynamic library handle twice (#70).
+  attempt to unload the same dynamic library handle twice (#71).
 
 # rdyncall 0.10.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# rdyncall 0.10.2
+
+- Make `dynunload()` idempotent after explicit unloads so finalizers do not
+  attempt to unload the same dynamic library handle twice (#70).
+
 # rdyncall 0.10.1
 
 - Build compiled tinytest fixtures from temporary source copies so CRAN checks

--- a/inst/tinytest/test_dynload.R
+++ b/inst/tinytest/test_dynload.R
@@ -19,8 +19,12 @@ if (Sys.info()[["sysname"]] == "Darwin") {
     expect_true(length(libm_symbols) < 1000L)
 }
 expect_null(dynunload(libm))
+expect_null(dynunload(libm))
+expect_false(rdyncall:::dynload_is_handle(libm))
+expect_error(dynsym(libm, "sqrt"), "not a lib handle")
 
 libr <- dynfind("R")
 expect_true(is.externalptr(libr))
 expect_true(is.externalptr(dynsym(libr, "R_ShowMessage")))
+expect_null(dynunload(libr))
 expect_null(dynunload(libr))

--- a/src/rdynload.c
+++ b/src/rdynload.c
@@ -18,11 +18,27 @@ static SEXP C_libhandle_tag(void)
   return Rf_install(RDYNCALL_LIBHANDLE_TAG);
 }
 
-static int C_is_libhandle(SEXP libh)
+/* A cleared libhandle can still be the same external pointer object, so keep
+ * tag validation separate from the live-address check below. */
+static int C_is_tagged_libhandle(SEXP libh)
 {
   return TYPEOF(libh) == EXTPTRSXP &&
-    R_ExternalPtrAddr(libh) != NULL &&
     R_ExternalPtrTag(libh) == C_libhandle_tag();
+}
+
+static int C_is_libhandle(SEXP libh)
+{
+  return C_is_tagged_libhandle(libh) &&
+    R_ExternalPtrAddr(libh) != NULL;
+}
+
+/* Centralize live-handle validation before passing the address to the dynload
+ * backend, which keeps post-unload handles from being dereferenced. */
+static void* C_checked_libhandle(SEXP libh)
+{
+  if (!C_is_libhandle(libh)) error("not a lib handle");
+
+  return R_ExternalPtrAddr(libh);
 }
 
 #if defined(__APPLE__)
@@ -175,11 +191,14 @@ SEXP C_dynunload(SEXP libobj_x)
 
   if (TYPEOF(libobj_x) != EXTPTRSXP) error("first argument is not of type external ptr.");
 
+  if (!C_is_tagged_libhandle(libobj_x)) error("not a lib handle");
+
   libHandle = R_ExternalPtrAddr(libobj_x);
 
-  if (!libHandle) error("not a lib handle");
+  if (!libHandle) return R_NilValue;
 
   dlFreeLibrary( libHandle );
+  R_ClearExternalPtr(libobj_x);
 
   return R_NilValue;
 }
@@ -197,7 +216,7 @@ SEXP C_dynsym(SEXP libh, SEXP symname_x, SEXP protectlib)
   const char* symbol;
   void* addr;
   SEXP protect;
-  libHandle = R_ExternalPtrAddr(libh);
+  libHandle = C_checked_libhandle(libh);
   symbol = CHAR(STRING_ELT(symname_x,0) );
   addr = dlFindSymbol( libHandle, symbol );
   protect = (LOGICAL(protectlib)[0]) ? libh : R_NilValue;
@@ -212,9 +231,9 @@ SEXP C_dynpath(SEXP libh)
   void* libHandle;
   SEXP ans;
 
-  ans = PROTECT(Rf_allocVector(STRSXP, 1));
+  libHandle = C_checked_libhandle(libh);
 
-  libHandle = R_ExternalPtrAddr(libh);
+  ans = PROTECT(Rf_allocVector(STRSXP, 1));
   size = dlGetLibraryPath(libHandle, buf, 1024);
   if (size >= 1) {
     if (size <= 1024) {


### PR DESCRIPTION
## Summary

Closes #70.

Fixes the `rdyncall` `0.10.1` BDR `valgrind` additional issue where an explicit `dynunload()` call could be followed by a finalizer-triggered second unload of the same dynamic library handle.

## Changes

- Makes `C_dynunload()` a no-op for already-cleared `rdyncall` library handles and clears the external pointer after a successful `dlFreeLibrary()` call.
- Adds focused `tinytest` coverage for repeated `dynunload()` on the same handle and for rejecting post-unload use via `dynsym()`.
- Updates `DESCRIPTION` and `NEWS.md` for `0.10.2`.
