### PR TITLE
ci: restore `R-hub` `valgrind` workflow

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -29,6 +29,11 @@ jobs:
       platforms: ${{ steps.rhub-setup.outputs.platforms }}
 
     steps:
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
       - uses: r-hub/rhub2/actions/rhub-setup@v1
         with:
           config: ${{ github.event.inputs.config }}
@@ -47,8 +52,16 @@ jobs:
       image: ${{ matrix.config.container }}
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: r-hub/rhub2/actions/rhub-check@v1
+      - uses: r-hub/rhub2/actions/rhub-checkout@v1
+      - uses: r-hub/rhub2/actions/rhub-platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/rhub2/actions/rhub-setup-deps@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/rhub2/actions/rhub-run-check@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
@@ -64,12 +77,20 @@ jobs:
         config: ${{ fromJson(needs.setup.outputs.platforms) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: r-hub/rhub2/actions/rhub-checkout@v1
       - uses: r-hub/rhub2/actions/rhub-setup-r@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/rhub2/actions/rhub-check@v1
+      - uses: r-hub/rhub2/actions/rhub-platform-info@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/rhub2/actions/rhub-setup-deps@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/rhub2/actions/rhub-run-check@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 - Make `dynunload()` idempotent after explicit unloads so finalizers do not
   attempt to unload the same dynamic library handle twice (#71).
 - Restore the manual `R-hub` workflow so `valgrind` checks can start from
-  GitHub Actions (#72).
+  GitHub Actions (#73).
 
 # rdyncall 0.10.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Make `dynunload()` idempotent after explicit unloads so finalizers do not
   attempt to unload the same dynamic library handle twice (#71).
+- Restore the manual `R-hub` workflow so `valgrind` checks can start from
+  GitHub Actions (#72).
 
 # rdyncall 0.10.1
 


### PR DESCRIPTION
## Summary

Closes #72.

Restores the manual `R-hub` workflow so `config=valgrind` can start from GitHub Actions instead of failing in the `setup` job with `R: command not found`.

## Changes

- Installs `R` with `r-lib/actions/setup-r@v2` before calling `r-hub/rhub2/actions/rhub-setup@v1`.
- Replaces the deprecated monolithic `r-hub/rhub2/actions/rhub-check@v1` action with the split `rhub-checkout`, `rhub-platform-info`, `rhub-setup-deps` and `rhub-run-check` action sequence.
- Updates `NEWS.md` with the `R-hub` `valgrind` workflow fix.
